### PR TITLE
PR: Add "Dockerfile".

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    && apt-get -y install curl git  \
+    && apt-get -y install cmake build-essential libilmbase-dev libraw-dev libboost-all-dev libgoogle-glog-dev libatlas-base-dev libeigen3-dev libsuitesparse-dev \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd ~ && git clone https://github.com/ampas/aces_container.git \
+    && mkdir aces_container/build && cd aces_container/build \
+    && cmake .. && make -j 4 && make install
+
+# Compiling "ceres-solver" requires a significant amount of memory, well over
+# the 2Go that Docker allocates by default, thus you will need to increase the
+# memory in Docker preferences: Preferences --> Resources --> Advanced, 8Go
+# should be enough.
+RUN cd ~ && curl -O http://ceres-solver.org/ceres-solver-1.14.0.tar.gz \
+    && tar zxf ceres-solver-1.14.0.tar.gz \
+    && mkdir ceres-solver-1.14.0/build && cd ceres-solver-1.14.0/build \
+    && cmake .. && make -j 4 && make install
+
+RUN cd ~ && git clone https://github.com/ampas/rawtoaces \
+    && mkdir rawtoaces/build && cd rawtoaces/build \
+    && cmake .. && make -j 4 && make install

--- a/README.md
+++ b/README.md
@@ -262,6 +262,27 @@ Ceres Solver is an open source library for solving Non-linear Least Squares prob
 
 ## Installation
 
+* Docker
+
+Assuming you have [Docker](https://www.docker.com/) installed, installing and
+running rawtoaces is relatively straightforward except for the compilation of
+*ceres-solver* that requires a significant amount of memory, well over
+the 2Go that Docker allocates by default. Thus you will need to increase the
+memory in Docker preferences: Preferences --> Resources --> Advanced, 8Go
+should be enough.
+
+	From the root source directory,	build the container:
+
+	```sh
+	$ docker build -f "Dockerfile" -t rawtoaces:latest "."
+	```
+
+	Then to run it from a directory with images:
+
+	```sh
+	$ docker run -it --rm -v $PWD:/tmp -w /tmp rawtoaces:latest rawtoaces IMG_1234.CR2
+	```
+
 * macOS
 	
 	Install homebrew if not already installed


### PR DESCRIPTION
This PR adds a *Dockerfile* to run *rawtoaces* in a container with [Docker](https://www.docker.com/):

Assuming that you have Docker and this PR pulled:

*Building the Container*

Note that the compilation of *ceres-solver* requires a significant amount of memory, well over the 2Go that Docker allocates by default. Thus you will need to increase the memory in Docker preferences: **Preferences --> Resources --> Advanced**, 8Go should be enough.

```sh
docker build -f "Dockerfile" -t rawtoaces:latest "."
```

*Running the Container*

```sh
docker run -it --rm -v $PWD:/tmp -w /tmp rawtoaces:latest rawtoaces IMG_1234.CR2
```