### PR TITLE
Fix build error with libraw 0.20.0

### DIFF
--- a/lib/rta.cpp
+++ b/lib/rta.cpp
@@ -1452,7 +1452,7 @@ namespace rta {
         _cameraXYZWhitePoint   = vector < double > ( 3, 1.0 );
         _calibrateIllum        = vector < double > ( 2, 1.0 );
         
-        _baseExpo = static_cast < double > ( R.color.baseline_exposure );
+        _baseExpo = static_cast < double > ( R.color.dng_levels.baseline_exposure );
         _calibrateIllum[0] = static_cast < double > ( R.color.dng_color[0].illuminant );
         _calibrateIllum[1] = static_cast < double > ( R.color.dng_color[1].illuminant );
         


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/58499

```
/tmp/rawtoaces-20200828-93437-1359dxi/rawtoaces-1.0/lib/rta.cpp:1455:54: error: no member named 'baseline_exposure' in 'libraw_colordata_t'
        _baseExpo = static_cast < double > ( R.color.baseline_exposure );
                                             ~~~~~~~ ^
```