### PR TITLE
fixed "baseline_exposure" missing error

### DIFF
--- a/lib/rta.cpp
+++ b/lib/rta.cpp
@@ -1452,7 +1452,7 @@ namespace rta {
         _cameraXYZWhitePoint   = vector < double > ( 3, 1.0 );
         _calibrateIllum        = vector < double > ( 2, 1.0 );
         
-        _baseExpo = static_cast < double > ( R.color.baseline_exposure );
+        _baseExpo = static_cast < double > ( R.color.dng_levels.baseline_exposure );
         _calibrateIllum[0] = static_cast < double > ( R.color.dng_color[0].illuminant );
         _calibrateIllum[1] = static_cast < double > ( R.color.dng_color[1].illuminant );
         


### PR DESCRIPTION
I was getting an error building that baseline_exposure wasn't a property of the color struct. Turns out it is a property of the dng levels struct