### PR TITLE
Use "ASWF" container as base.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,44 @@
-FROM ubuntu:bionic
+# https://hub.docker.com/r/aswf/ci-vfxall/tags
+FROM aswf/ci-vfxall:2022
 
-ENV DEBIAN_FRONTEND=noninteractive
+# Base Building Dependencies.
+RUN yum install --setopt=tsflags=nodocs -y \
+    blas-devel \
+    lapack-devel \
+    eigen3-devel \
+    gflags-devel \
+    glog-devel \
+    suitesparse-devel \
+    && ln -s /usr/include/eigen3/Eigen /usr/include/Eigen
 
-RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    && apt-get -y install curl git  \
-    && apt-get -y install cmake build-essential libilmbase-dev libraw-dev libboost-all-dev libgoogle-glog-dev libatlas-base-dev libeigen3-dev libsuitesparse-dev \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN cd ~ && git clone https://github.com/ampas/aces_container.git \
+# aces-container
+WORKDIR /tmp
+RUN git clone https://github.com/ampas/aces_container.git \
     && mkdir aces_container/build && cd aces_container/build \
     && cmake .. && make -j 4 && make install
 
+# ceres-solver
 # Compiling "ceres-solver" requires a significant amount of memory, well over
 # the 2Go that Docker allocates by default, thus you will need to increase the
 # memory in Docker preferences: Preferences --> Resources --> Advanced, 8Go
 # should be enough.
-RUN cd ~ && curl -O http://ceres-solver.org/ceres-solver-1.14.0.tar.gz \
+WORKDIR /tmp
+RUN curl -O http://ceres-solver.org/ceres-solver-1.14.0.tar.gz \
     && tar zxf ceres-solver-1.14.0.tar.gz \
     && mkdir ceres-solver-1.14.0/build && cd ceres-solver-1.14.0/build \
     && cmake .. && make -j 4 && make install
 
-RUN cd ~ && git clone https://github.com/ampas/rawtoaces \
-    && mkdir rawtoaces/build && cd rawtoaces/build \
+# libraw
+WORKDIR /tmp
+RUN git clone https://github.com/LibRaw/LibRaw.git \
+    && cd LibRaw && git checkout 0.21.1 \
+    && autoreconf --install \
+    && ./configure && make -j 4 && make install
+
+ARG CACHE_DATE
+
+RUN mkdir -p /home/aswf/rawtoaces
+WORKDIR /home/aswf/rawtoaces
+COPY . /home/aswf/rawtoaces
+RUN mkdir build && cd build \
     && cmake .. && make -j 4 && make install


### PR DESCRIPTION
This PR uses the `aswf/ci-vfxall:2022` container as a base rather than *Ubuntu* previously.

Note that the 2023 container did not work when I tried, hence the 2022.