### PR TITLE
add more CI platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,75 @@ on:
     #branches: [ "master" ]
 
 jobs:
+  aswf_old:
+    name: "VFX${{matrix.vfxyear}} ${{matrix.desc}}"
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+      
+      matrix:
+        include:
+          - desc: gcc11
+            nametag: linux-vfx2022-gcc11
+            os: ubuntu-latest
+            container: aswf/ci-osl:2022-clang11
+            vfxyear: 2022
+            cxx_std: 17
+          - desc: clang14
+            nametag: linux-vfx2022-clang14
+            os: ubuntu-latest
+            container: aswf/ci-osl:2022-clang11
+            vfxyear: 2022
+            cc_compiler: clang
+            cxx_compiler: clang++
+            cxx_std: 17
+        
+    runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.container }}
+      volumes:
+        - /node20217:/node20217:rw,rshared
+        - /node20217:/__e/node20:ro,rshared
+    env:
+      CXX: ${{matrix.cxx_compiler}}
+      CC: ${{matrix.cc_compiler}}
+      CMAKE_CXX_STANDARD: ${{matrix.cxx_std}}
+      OPENEXR_VERSION: ${{matrix.openexr_ver}}
+    steps:
+      - name: install nodejs20glibc2.17
+        run: |
+          curl --silent https://unofficial-builds.nodejs.org/download/release/v20.18.1/node-v20.18.1-linux-x64-glibc-217.tar.xz | tar -xJ --strip-components 1 -C /node20217 -f -
+            
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: '0'
+
+      - name: Yum config
+        shell: bash
+        run: |
+          yum-config-manager --disable centos-sclo-rh || true
+          sed -i 's,^mirrorlist=,#,; s,^#baseurl=http://mirror\.centos\.org/centos/$releasever,baseurl=https://vault.centos.org/7.9.2009,' /etc/yum.repos.d/CentOS-Base.repo
+          
+      - name: Dependencies
+        shell: bash
+        run: |
+            build_scripts/install_aces_container.bash
+            sudo yum install --setopt=tsflags=nodocs -y eigen3-devel ceres-solver-devel LibRaw-devel
+
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: >
+            cmake -B build -S . -DRTA_CENTOS7_CERES_HACK=ON
+
+      - name: Build
+        run: sudo cmake --build build
+
+      - name: Test
+        working-directory: build
+        run: ctest --rerun-failed --output-on-failure
+
   aswf:
     name: "VFX${{matrix.vfxyear}} ${{matrix.desc}}"
     runs-on: ${{ matrix.os }}
@@ -28,17 +97,34 @@ jobs:
             vfxyear: 2023
             cxx_std: 17
           - desc: clang15 # /C++17 boost1.8 exr3.1
-            nametag: linux-vfx2022-clang13
+            nametag: linux-vfx2022-clang15
             os: ubuntu-latest
             container: aswf/ci-osl:2023-clang15
             vfxyear: 2023
             cc_compiler: clang
             cxx_compiler: clang++
             cxx_std: 17
+            
+          - desc: gcc11
+            nametag: linux-vfx2024
+            os: ubuntu-latest
+            container: aswf/ci-osl:2024-clang17
+            vfxyear: 2024
+            cxx_std: 17
+          - desc: clang17
+            nametag: linux-vfx2024-clang17
+            os: ubuntu-latest
+            container: aswf/ci-osl:2024-clang17
+            vfxyear: 2024
+            cc_compiler: clang
+            cxx_compiler: clang++
+            cxx_std: 17
+
     env:
       CXX: ${{matrix.cxx_compiler}}
       CC: ${{matrix.cc_compiler}}
       CMAKE_CXX_STANDARD: ${{matrix.cxx_std}}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -96,14 +182,17 @@ jobs:
             c_compiler: gcc
             cpp_compiler: g++
             install_deps: install_deps_linux
+            build_shared_libs: ON
           - os: ubuntu-latest
             c_compiler: clang
             cpp_compiler: clang++
             install_deps: install_deps_linux
+            build_shared_libs: ON
           - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
             install_deps: install_deps_mac
+            build_shared_libs: ON
         exclude:
           - os: windows-latest
             c_compiler: gcc
@@ -115,7 +204,7 @@ jobs:
             c_compiler: cl
           - os: macos-latest
             c_compiler: gcc
-
+      
     steps:
     - uses: actions/checkout@v4
 
@@ -139,7 +228,7 @@ jobs:
         cmake
         -B ${{ steps.strings.outputs.build-output-dir }}
         -S ${{ github.workspace }}
-        -DCXX_STANDARD=C++14
+        -DCXX_STANDARD=C++17
         -DCMAKE_TOOLCHAIN_FILE="${{ matrix.toolchain_file }}"
         -DENABLE_SHARED="${{ matrix.build_shared_libs }}"
         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ foreach( p LIB BIN INCLUDE CMAKE )
 endforeach()
 
 option( ENABLE_SHARED "Enable Shared Libraries" ON )
+option( RTA_CENTOS7_CERES_HACK "Work around broken config in ceres-solver 1.12" OFF )
 
 if ( ENABLE_SHARED )
   set ( DO_SHARED SHARED )

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ To build `rawtoaces` you would need to sutisfy these dependencies:
 | Library          | Min Version| Purpose  | Link to installation instruction |
 | -------          | -----------| -------- | -------------------------------- |
 | `cmake`          | `3.10`     | | [CMake download](https://cmake.org/download/)|
-| `ceres`          | `1.14.0`   | Ceres Solver is an open source library for solving Non-linear Least Squares problems with bounds constraints and unconstrained optimization problems. It processes non-linear regression for rawtoaces.  | [Ceres Solver installation](http://ceres-solver.org/installation.html)|
+| `ceres`          | `1.12.0`   | Ceres Solver is an open source library for solving Non-linear Least Squares problems with bounds constraints and unconstrained optimization problems. It processes non-linear regression for rawtoaces.  | [Ceres Solver installation](http://ceres-solver.org/installation.html)|
 | `imath`          | `3.1.8`    | Provides the half data type used for representing 16-bit floating-point values. It's used by rawtoaces for storing high dynamic range (HDR) data in a compact format. | [Imath installation](https://imath.readthedocs.io/en/latest/install.html#install)|
-| `libraw`         | `0.19.5`   | LibRaw is a library that processes RAW files from digital cameras. It handles image pre-processing for rawtoaces. | [LibRaw download](http://www.libraw.org/download) |
-| `boost`          | `1.80.0`   | Boost has multiple C++ libraries that support tasks related to linear algebra, multithreading, image processing, unit testing, etc. It handles data loading and unit testing for rawtoaces. | [Boost download](http://www.boost.org/) |
+| `libraw`         | `0.19.4`   | LibRaw is a library that processes RAW files from digital cameras. It handles image pre-processing for rawtoaces. | [LibRaw download](http://www.libraw.org/download) |
+| `boost`          | `1.76.0`   | Boost has multiple C++ libraries that support tasks related to linear algebra, multithreading, image processing, unit testing, etc. It handles data loading and unit testing for rawtoaces. | [Boost download](http://www.boost.org/) |
 | `aces_container` | `latest`   | ACES Container is the reference implementation for a file writer intended to be used with the Academy Color Encoding System (ACES). `rawtoaces` relies on it to produce images that comply with the ACES container specification (SMPTE S2065-4). | [ACES Container installation](https://github.com/ampas/aces_container?tab=readme-ov-file#installation) |
 
 

--- a/cmake/modules/FindCeres.cmake
+++ b/cmake/modules/FindCeres.cmake
@@ -1,0 +1,11 @@
+#
+# This is a hack to make rawtoaces build on Centos 7 on CI.
+# ceres-solver-1.12 which is available via yum on Centos 7 comes with
+# broken Config.cmake file. This hack works around that. It requires that
+# ceres-solver-1.12 is already installed via yum.
+#
+
+set (Ceres_VERSION_MAJOR 0)
+set (CERES_INCLUDE_DIRS "/usr/include")
+set (CERES_LIBRARIES "/usr/lib64/libceres.so")
+set (Ceres_FOUND 1)

--- a/configure.cmake
+++ b/configure.cmake
@@ -6,13 +6,18 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_INSTALL_PREFIX}/share/CMake"
 find_package ( AcesContainer CONFIG REQUIRED )
 find_package ( Eigen3        CONFIG REQUIRED )
 find_package ( Imath         CONFIG REQUIRED )
-find_package ( Ceres                REQUIRED )
 find_package ( Boost                REQUIRED
     COMPONENTS
         system
         filesystem
         unit_test_framework
 )
+
+if (RTA_CENTOS7_CERES_HACK)
+    find_package ( Ceres MODULE REQUIRED )
+else ()
+    find_package ( Ceres CONFIG REQUIRED )
+endif ()
 
 find_package (libraw CONFIG QUIET )
 

--- a/src/rawtoaces_idt/CMakeLists.txt
+++ b/src/rawtoaces_idt/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(
         Boost::filesystem
         Imath::Imath
         Imath::ImathConfig
+	Eigen3::Eigen
 )
 
 if ( ${Ceres_VERSION_MAJOR} GREATER 1 )

--- a/src/rawtoaces_idt/rta.cpp
+++ b/src/rawtoaces_idt/rta.cpp
@@ -1028,12 +1028,14 @@ void Idt::loadCMF( const string &path )
         BOOST_FOREACH (
             ptree::value_type &row, pt.get_child( "spectral_data.data.main" ) )
         {
-            _cmf[i]._wl = atoi( ( row.first ).c_str() );
+            uint16_t wl = atoi( ( row.first ).c_str() );
 
-            if ( _cmf[i]._wl < 380 || _cmf[i]._wl % 5 )
+            if ( wl < 380 || wl % 5 )
                 continue;
-            else if ( _cmf[i]._wl > 780 )
+            else if ( wl > 780 )
                 break;
+
+            _cmf[i]._wl = wl;
 
             vector<double> data;
             BOOST_FOREACH ( ptree::value_type &cell, row.second )

--- a/unittest/testDNGIdt.cpp
+++ b/unittest/testDNGIdt.cpp
@@ -55,7 +55,7 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <rawtoaces/rta.h>
 

--- a/unittest/testIDT.cpp
+++ b/unittest/testIDT.cpp
@@ -60,7 +60,7 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <rawtoaces/mathOps.h>
 #include <rawtoaces/rta.h>

--- a/unittest/testIllum.cpp
+++ b/unittest/testIllum.cpp
@@ -60,7 +60,7 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <rawtoaces/mathOps.h>
 #include <rawtoaces/rta.h>

--- a/unittest/testLogic.cpp
+++ b/unittest/testLogic.cpp
@@ -54,7 +54,7 @@
 
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <rawtoaces/mathOps.h>
 

--- a/unittest/testMath.cpp
+++ b/unittest/testMath.cpp
@@ -60,7 +60,7 @@
 
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <rawtoaces/mathOps.h>
 

--- a/unittest/testSpst.cpp
+++ b/unittest/testSpst.cpp
@@ -60,7 +60,7 @@
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <rawtoaces/mathOps.h>
 #include <rawtoaces/rta.h>


### PR DESCRIPTION
Adds VFX2022 and VFX2024 CI runners.
Fixes the build on VFX2022 (Centos 7).
Fixes a few deprecation warnings.
Fixes a potential crash writing out of bounds.