### PR TITLE
Update GitHub org to AcademySoftwareFoundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ The following commands will convert RAW to ACES using the camera file metadata f
 
 ## Known Issues
 
-For a list of currently known issues see the [issues list](https://github.com/ampas/rawtoaces/issues) in github. Please add any issue found to the github list.
+For a list of currently known issues see the [issues list](https://github.com/AcademySoftwareFoundation/rawtoaces/issues) in github. Please add any issue found to the github list.
 
 ## Installation for Redhat
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ vcpkg install \
 From the root source directory:
 	
 ```sh
-$ git clone https://github.com/ampas/rawtoaces
+$ git clone https://github.com/AcademySoftwareFoundation/rawtoaces
 $ cd rawtoaces
 $ cmake -S . -B build
 $ cmake --build build


### PR DESCRIPTION
Although GitHub repo URLs will redirect from the previous organization a repo lived under,
update README.md to reflect the current org.
