### PR TITLE
v2 - remove the dependency on libraw from the core library

### DIFF
--- a/include/rawtoaces/acesrender.h
+++ b/include/rawtoaces/acesrender.h
@@ -7,6 +7,7 @@
 #include <rawtoaces/rta.h>
 
 #include <unordered_map>
+#include <libraw/libraw.h>
 
 using namespace rta;
 
@@ -72,7 +73,7 @@ private:
     const AcesRender &operator=( const AcesRender &acesrender );
 
     char                     *_pathToRaw;
-    Idt                      *_idt;
+    core::Idt                *_idt;
     libraw_processed_image_t *_image;
     LibRawAces               *_rawProcessor;
 

--- a/include/rawtoaces/rta.h
+++ b/include/rawtoaces/rta.h
@@ -1,26 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the rawtoaces Project.
 
-#ifndef _RTA_h__
-#define _RTA_h__
+#pragma once
 
 #include "define.h"
 
 #include <stdint.h>
-#include <libraw/libraw.h>
 
 using namespace std;
 
 namespace rta
 {
-struct CIEXYZ
+namespace core
 {
-    CIEXYZ(){};
-    CIEXYZ( double X, double Y, double Z ) : _Xt( X ), _Yt( Y ), _Zt( Z ){};
-    double _Xt;
-    double _Yt;
-    double _Zt;
-};
 
 struct trainSpec
 {
@@ -171,12 +163,61 @@ private:
     vector<vector<double>> _idt;
 };
 
+struct Metadata
+{
+    struct Calibration
+    {
+        unsigned short      illuminant = 0;
+        std::vector<double> cameraCalibrationMatrix;
+        std::vector<double> xyz2rgbMatrix;
+
+        friend bool operator==( const Calibration &c1, const Calibration &c2 )
+        {
+            if ( c1.illuminant != c2.illuminant )
+                return false;
+            if ( c1.cameraCalibrationMatrix != c2.cameraCalibrationMatrix )
+                return false;
+            if ( c1.xyz2rgbMatrix != c2.xyz2rgbMatrix )
+                return false;
+
+            return true;
+        }
+
+        friend bool operator!=( const Calibration &c1, const Calibration &c2 )
+        {
+            return !( c1 == c2 );
+        }
+    } calibration[2];
+
+    std::vector<double> neutralRGB;
+    double              baselineExposure = 0.0;
+
+    friend bool operator==( const Metadata &m1, const Metadata &m2 )
+    {
+        if ( m1.calibration[0] != m2.calibration[0] )
+            return false;
+        if ( m1.calibration[1] != m2.calibration[1] )
+            return false;
+        if ( m1.baselineExposure != m2.baselineExposure )
+            return false;
+        if ( m1.neutralRGB != m2.neutralRGB )
+            return false;
+
+        return true;
+    }
+
+    friend bool operator!=( const Metadata &m1, const Metadata &m2 )
+    {
+        return !( m1 == m2 );
+    }
+};
+
 class DNGIdt
 {
+    core::Metadata _metadata;
+
 public:
-    DNGIdt();
-    DNGIdt( libraw_rawdata_t R );
-    virtual ~DNGIdt();
+    DNGIdt( const core::Metadata &metadata );
 
     double ccttoMired( const double cct ) const;
     double robertsonLength(
@@ -196,16 +237,8 @@ public:
     void                   getCameraXYZMtxAndWhitePoint();
 
 private:
-    vector<double> _cameraCalibration1DNG;
-    vector<double> _cameraCalibration2DNG;
     vector<double> _cameraToXYZMtx;
-    vector<double> _xyz2rgbMatrix1DNG;
-    vector<double> _xyz2rgbMatrix2DNG;
-    vector<double> _analogBalanceDNG;
-    vector<double> _neutralRGBDNG;
     vector<double> _cameraXYZWhitePoint;
-    vector<double> _calibrateIllum;
-    double         _baseExpo;
 };
 
 struct Objfun
@@ -222,5 +255,5 @@ struct Objfun
     const vector<vector<double>> _outLAB;
 };
 
+} // namespace core
 } // namespace rta
-#endif

--- a/src/rawtoaces_idt/CMakeLists.txt
+++ b/src/rawtoaces_idt/CMakeLists.txt
@@ -31,14 +31,6 @@ else ()
     target_link_libraries(${RAWTOACESIDTLIB} PUBLIC ${CERES_LIBRARIES})
 endif ()
 
-if ( LIBRAW_CONFIG_FOUND )
-    target_link_libraries ( ${RAWTOACESIDTLIB} PUBLIC libraw::raw )
-else ()
-    target_include_directories(${RAWTOACESIDTLIB} PUBLIC ${libraw_INCLUDE_DIR} )
-    target_link_directories(${RAWTOACESIDTLIB} PUBLIC ${libraw_LIBRARY_DIRS} )
-    target_link_libraries(${RAWTOACESIDTLIB} PUBLIC ${libraw_LIBRARIES} ${libraw_LDFLAGS_OTHER} )
-endif ()
-
 target_include_directories( ${RAWTOACESIDTLIB} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
     $<INSTALL_INTERFACE:./include>

--- a/src/rawtoaces_idt/rta.cpp
+++ b/src/rawtoaces_idt/rta.cpp
@@ -1628,7 +1628,7 @@ DNGIdt::findXYZtoCameraMtx( const vector<double> &neutralRGB ) const
         lerror =
             mir - ccttoMired( XYZToColorTemperature( mulVector(
                       invertV( XYZtoCameraWeightedMatrix( mir, mir1, mir2 ) ),
-                      _metadata.neutralRGB ) ) );
+                      neutralRGB ) ) );
 
         if ( std::fabs( lerror - 0.0 ) <= 1e-09 )
         {

--- a/src/rawtoaces_idt/rta.cpp
+++ b/src/rawtoaces_idt/rta.cpp
@@ -13,6 +13,9 @@ using namespace ceres;
 
 namespace rta
 {
+namespace core
+{
+
 Illum::Illum()
 {
     _inc = 5;
@@ -1492,70 +1495,8 @@ const vector<double> Idt::getWB() const
 
 // ------------------------------------------------------//
 
-DNGIdt::DNGIdt()
-{
-    _cameraCalibration1DNG = vector<double>( 9, 1.0 );
-    _cameraCalibration2DNG = vector<double>( 9, 1.0 );
-    _cameraToXYZMtx        = vector<double>( 9, 1.0 );
-    _xyz2rgbMatrix1DNG     = vector<double>( 9, 1.0 );
-    _xyz2rgbMatrix2DNG     = vector<double>( 9, 1.0 );
-    _analogBalanceDNG      = vector<double>( 3, 1.0 );
-    _neutralRGBDNG         = vector<double>( 3, 1.0 );
-    _cameraXYZWhitePoint   = vector<double>( 3, 1.0 );
-    _calibrateIllum        = vector<double>( 2, 1.0 );
-    _baseExpo              = 1.0;
-}
-
-DNGIdt::DNGIdt( libraw_rawdata_t R )
-{
-    _cameraCalibration1DNG = vector<double>( 9, 1.0 );
-    _cameraCalibration2DNG = vector<double>( 9, 1.0 );
-    _cameraToXYZMtx        = vector<double>( 9, 1.0 );
-    _xyz2rgbMatrix1DNG     = vector<double>( 9, 1.0 );
-    _xyz2rgbMatrix2DNG     = vector<double>( 9, 1.0 );
-    _analogBalanceDNG      = vector<double>( 3, 1.0 );
-    _neutralRGBDNG         = vector<double>( 3, 1.0 );
-    _cameraXYZWhitePoint   = vector<double>( 3, 1.0 );
-    _calibrateIllum        = vector<double>( 2, 1.0 );
-
-#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION( 0, 20, 0 )
-    _baseExpo = static_cast<double>( R.color.dng_levels.baseline_exposure );
-#else
-    _baseExpo = static_cast<double>( R.color.baseline_exposure );
-#endif
-    _calibrateIllum[0] = static_cast<double>( R.color.dng_color[0].illuminant );
-    _calibrateIllum[1] = static_cast<double>( R.color.dng_color[1].illuminant );
-
-    FORI( 3 )
-    {
-        _neutralRGBDNG[i] = 1.0 / static_cast<double>( R.color.cam_mul[i] );
-    }
-
-    FORIJ( 3, 3 )
-    {
-        _xyz2rgbMatrix1DNG[i * 3 + j] =
-            static_cast<double>( ( R.color.dng_color[0].colormatrix )[i][j] );
-        _xyz2rgbMatrix2DNG[i * 3 + j] =
-            static_cast<double>( ( R.color.dng_color[1].colormatrix )[i][j] );
-        _cameraCalibration1DNG[i * 3 + j] =
-            static_cast<double>( ( R.color.dng_color[0].calibration )[i][j] );
-        _cameraCalibration2DNG[i * 3 + j] =
-            static_cast<double>( ( R.color.dng_color[1].calibration )[i][j] );
-    }
-}
-
-DNGIdt::~DNGIdt()
-{
-    clearVM( _cameraCalibration1DNG );
-    clearVM( _cameraCalibration2DNG );
-    clearVM( _cameraToXYZMtx );
-    clearVM( _xyz2rgbMatrix1DNG );
-    clearVM( _xyz2rgbMatrix2DNG );
-    clearVM( _analogBalanceDNG );
-    clearVM( _neutralRGBDNG );
-    clearVM( _cameraXYZWhitePoint );
-    clearVM( _calibrateIllum );
-}
+DNGIdt::DNGIdt( const core::Metadata &metadata ) : _metadata( metadata )
+{}
 
 double DNGIdt::ccttoMired( const double cct ) const
 {
@@ -1639,10 +1580,11 @@ vector<double> DNGIdt::XYZtoCameraWeightedMatrix(
 
     double weight =
         std::max( 0.0, std::min( 1.0, ( mir1 - mir0 ) / ( mir1 - mir2 ) ) );
-    vector<double> result =
-        subVectors( _xyz2rgbMatrix2DNG, _xyz2rgbMatrix1DNG );
+    vector<double> result = subVectors(
+        _metadata.calibration[1].xyz2rgbMatrix,
+        _metadata.calibration[0].xyz2rgbMatrix );
     scaleVector( result, weight );
-    result = addVectors( result, _xyz2rgbMatrix1DNG );
+    result = addVectors( result, _metadata.calibration[0].xyz2rgbMatrix );
 
     return result;
 }
@@ -1651,22 +1593,20 @@ vector<double>
 DNGIdt::findXYZtoCameraMtx( const vector<double> &neutralRGB ) const
 {
 
-    if ( _calibrateIllum.size() == 0 )
+    if ( _metadata.calibration[0].illuminant == 0 )
     {
         fprintf( stderr, " No calibration illuminants were found. \n " );
-        return _xyz2rgbMatrix1DNG;
+        return _metadata.calibration[0].xyz2rgbMatrix;
     }
 
     if ( neutralRGB.size() == 0 )
     {
         fprintf( stderr, " no neutral RGB values were found. \n " );
-        return _xyz2rgbMatrix1DNG;
+        return _metadata.calibration[0].xyz2rgbMatrix;
     }
 
-    double cct1 = lightSourceToColorTemp(
-        static_cast<const unsigned short>( _calibrateIllum[0] ) );
-    double cct2 = lightSourceToColorTemp(
-        static_cast<const unsigned short>( _calibrateIllum[1] ) );
+    double cct1 = lightSourceToColorTemp( _metadata.calibration[0].illuminant );
+    double cct2 = lightSourceToColorTemp( _metadata.calibration[1].illuminant );
 
     double mir1 = ccttoMired( cct1 );
     double mir2 = ccttoMired( cct2 );
@@ -1688,7 +1628,7 @@ DNGIdt::findXYZtoCameraMtx( const vector<double> &neutralRGB ) const
         lerror =
             mir - ccttoMired( XYZToColorTemperature( mulVector(
                       invertV( XYZtoCameraWeightedMatrix( mir, mir1, mir2 ) ),
-                      _neutralRGBDNG ) ) );
+                      _metadata.neutralRGB ) ) );
 
         if ( std::fabs( lerror - 0.0 ) <= 1e-09 )
         {
@@ -1788,19 +1728,20 @@ vector<double> DNGIdt::matrixRGBtoXYZ( const double chromaticities[][2] ) const
 
 void DNGIdt::getCameraXYZMtxAndWhitePoint()
 {
-    _cameraToXYZMtx = invertV( findXYZtoCameraMtx( _neutralRGBDNG ) );
+    _cameraToXYZMtx = invertV( findXYZtoCameraMtx( _metadata.neutralRGB ) );
     assert( std::fabs( sumVector( _cameraToXYZMtx ) - 0.0 ) > 1e-09 );
 
-    scaleVector( _cameraToXYZMtx, std::pow( 2.0, _baseExpo ) );
+    scaleVector( _cameraToXYZMtx, std::pow( 2.0, _metadata.baselineExposure ) );
 
-    if ( _neutralRGBDNG.size() > 0 )
+    if ( _metadata.neutralRGB.size() > 0 )
     {
-        _cameraXYZWhitePoint = mulVector( _cameraToXYZMtx, _neutralRGBDNG );
+        _cameraXYZWhitePoint =
+            mulVector( _cameraToXYZMtx, _metadata.neutralRGB );
     }
     else
     {
         _cameraXYZWhitePoint = colorTemperatureToXYZ(
-            lightSourceToColorTemp( _calibrateIllum[0] ) );
+            lightSourceToColorTemp( _metadata.calibration[0].illuminant ) );
     }
 
     scaleVector( _cameraXYZWhitePoint, 1.0 / _cameraXYZWhitePoint[1] );
@@ -1866,4 +1807,5 @@ template <typename T> bool Objfun::operator()( const T *B, T *residuals ) const
     return true;
 }
 
+} // namespace core
 } // namespace rta

--- a/src/rawtoaces_util/CMakeLists.txt
+++ b/src/rawtoaces_util/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries ( ${RAWTOACESLIB}
 if ( LIBRAW_CONFIG_FOUND )
     target_link_libraries ( ${RAWTOACESLIB} PUBLIC libraw::raw )
 else ()
+    target_include_directories(${RAWTOACESLIB} PUBLIC ${libraw_INCLUDE_DIR} )
     target_link_directories(${RAWTOACESLIB} PUBLIC ${libraw_LIBRARY_DIRS} )
     target_link_libraries(${RAWTOACESLIB} PUBLIC ${libraw_LIBRARIES} ${libraw_LDFLAGS_OTHER} )
 endif ()

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -64,6 +64,14 @@ target_link_libraries(
         Boost::unit_test_framework
 )
 
+if ( LIBRAW_CONFIG_FOUND )
+    target_link_libraries ( Test_DNGIdt PUBLIC libraw::raw )
+else ()
+    target_include_directories(Test_DNGIdt PUBLIC ${libraw_INCLUDE_DIR} )
+    target_link_directories(Test_DNGIdt PUBLIC ${libraw_LIBRARY_DIRS} )
+    target_link_libraries(Test_DNGIdt PUBLIC ${libraw_LIBRARIES} ${libraw_LDFLAGS_OTHER} )
+endif ()
+
 add_test ( NAME Test_DNGIdt COMMAND Test_DNGIdt )
 
 ################################################################################

--- a/unittest/testDNGIdt.cpp
+++ b/unittest/testDNGIdt.cpp
@@ -7,16 +7,18 @@
 #include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <rawtoaces/rta.h>
+#include <libraw/libraw.h>
 
 using namespace std;
 using namespace rta;
+using namespace rta::core;
 
 BOOST_AUTO_TEST_CASE( TestIDT_CcttoMired )
 {
-
-    DNGIdt *di    = new DNGIdt();
-    double  cct   = 6500.0;
-    double  mired = di->ccttoMired( cct );
+    Metadata metadata;
+    DNGIdt  *di    = new DNGIdt( metadata );
+    double   cct   = 6500.0;
+    double   mired = di->ccttoMired( cct );
     delete di;
 
     BOOST_CHECK_CLOSE( mired, 153.8461538462, 1e-5 );
@@ -24,8 +26,8 @@ BOOST_AUTO_TEST_CASE( TestIDT_CcttoMired )
 
 BOOST_AUTO_TEST_CASE( TestIDT_RobertsonLength )
 {
-
-    DNGIdt        *di    = new DNGIdt();
+    Metadata       metadata;
+    DNGIdt        *di    = new DNGIdt( metadata );
     double         uv[]  = { 0.2042589852, 0.3196233991 };
     double         uvt[] = { 0.1800600000, 0.2635200000, -0.2434100000 };
     vector<double> uvVector( uv, uv + 2 );
@@ -39,14 +41,54 @@ BOOST_AUTO_TEST_CASE( TestIDT_RobertsonLength )
 
 BOOST_AUTO_TEST_CASE( TestIDT_LightSourceToColorTemp )
 {
-
-    DNGIdt        *di  = new DNGIdt();
+    Metadata       metadata;
+    DNGIdt        *di  = new DNGIdt( metadata );
     unsigned short tag = 17;
     double         ct  = di->lightSourceToColorTemp( tag );
     delete di;
 
     BOOST_CHECK_CLOSE( ct, 2856.0, 1e-5 );
 };
+
+void init_metadata( const LibRaw &libraw, Metadata &metadata )
+{
+    metadata.neutralRGB.resize( 3 );
+    metadata.calibration[0].xyz2rgbMatrix.resize( 9 );
+    metadata.calibration[1].xyz2rgbMatrix.resize( 9 );
+    metadata.calibration[0].cameraCalibrationMatrix.resize( 9 );
+    metadata.calibration[1].cameraCalibrationMatrix.resize( 9 );
+
+    const libraw_colordata_t &color = libraw.imgdata.rawdata.color;
+
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION( 0, 20, 0 )
+    metadata.baselineExposure =
+        static_cast<double>( color.dng_levels.baseline_exposure );
+#else
+    metadata.baselineExposure = static_cast<double>( color.baseline_exposure );
+#endif
+
+    for ( int i = 0; i < 3; i++ )
+    {
+        metadata.neutralRGB[i] = 1.0 / static_cast<double>( color.cam_mul[i] );
+    }
+
+    for ( int k = 0; k < 2; k++ )
+    {
+        metadata.calibration[k].illuminant =
+            static_cast<double>( color.dng_color[k].illuminant );
+
+        for ( int i = 0; i < 3; i++ )
+        {
+            for ( int j = 0; j < 3; j++ )
+            {
+                metadata.calibration[k].xyz2rgbMatrix[i * 3 + j] =
+                    color.dng_color[k].colormatrix[i][j];
+                metadata.calibration[k].cameraCalibrationMatrix[i * 3 + j] =
+                    color.dng_color[k].calibration[i][j];
+            }
+        }
+    }
+}
 
 BOOST_AUTO_TEST_CASE( TestIDT_XYZToColorTemperature )
 {
@@ -56,7 +98,9 @@ BOOST_AUTO_TEST_CASE( TestIDT_XYZToColorTemperature )
     int ret = rawProcessor.open_file( ( pathToRaw.string() ).c_str() );
     ret     = rawProcessor.unpack();
 
-    DNGIdt        *di     = new DNGIdt( rawProcessor.imgdata.rawdata );
+    Metadata metadata;
+    init_metadata( rawProcessor, metadata );
+    DNGIdt        *di     = new DNGIdt( metadata );
     double         XYZ[3] = { 0.9731171910, 1.0174927152, 0.9498565880 };
     vector<double> XYZVector( XYZ, XYZ + 3 );
     double         cct = di->XYZToColorTemperature( XYZVector );
@@ -75,7 +119,9 @@ BOOST_AUTO_TEST_CASE( TestIDT_XYZtoCameraWeightedMatrix )
     int ret = rawProcessor.open_file( ( pathToRaw.string() ).c_str() );
     ret     = rawProcessor.unpack();
 
-    DNGIdt        *di      = new DNGIdt( rawProcessor.imgdata.rawdata );
+    Metadata metadata;
+    init_metadata( rawProcessor, metadata );
+    DNGIdt        *di      = new DNGIdt( metadata );
     double         mirs[3] = { 158.8461538462, 350.1400560224, 153.8461538462 };
     double         matrix[9] = { 1.0165710542,  -0.2791973987, -0.0801820653,
                                  -0.4881171650, 1.3469051835,  0.1100471308,
@@ -97,7 +143,9 @@ BOOST_AUTO_TEST_CASE( TestIDT_FindXYZtoCameraMtx )
     int ret = rawProcessor.open_file( ( pathToRaw.string() ).c_str() );
     ret     = rawProcessor.unpack();
 
-    DNGIdt        *di            = new DNGIdt( rawProcessor.imgdata.rawdata );
+    Metadata metadata;
+    init_metadata( rawProcessor, metadata );
+    DNGIdt        *di            = new DNGIdt( metadata );
     double         neutralRGB[3] = { 0.6289999865, 1.0000000000, 0.7904000305 };
     double         matrix[9] = { 1.0616656923,  -0.3124143737, -0.0661770211,
                                  -0.4772957633, 1.3614785395,  0.1001599918,
@@ -114,8 +162,8 @@ BOOST_AUTO_TEST_CASE( TestIDT_FindXYZtoCameraMtx )
 
 BOOST_AUTO_TEST_CASE( TestIDT_ColorTemperatureToXYZ )
 {
-
-    DNGIdt        *di     = new DNGIdt();
+    Metadata       metadata;
+    DNGIdt        *di     = new DNGIdt( metadata );
     double         cct    = 6500.0;
     double         XYZ[3] = { 0.3135279229, 0.3235340821, 0.3629379950 };
     vector<double> result = di->colorTemperatureToXYZ( cct );
@@ -127,8 +175,8 @@ BOOST_AUTO_TEST_CASE( TestIDT_ColorTemperatureToXYZ )
 
 BOOST_AUTO_TEST_CASE( TestIDT_MatrixRGBtoXYZ )
 {
-
-    DNGIdt        *di     = new DNGIdt();
+    Metadata       metadata;
+    DNGIdt        *di     = new DNGIdt( metadata );
     double         XYZ[9] = { 0.952552395938, 0.000000000000, 0.000093678632,
                               0.343966449765, 0.728166096613, -0.072132546379,
                               0.000000000000, 0.000000000000, 1.008825184352 };
@@ -148,7 +196,9 @@ BOOST_AUTO_TEST_CASE( TestIDT_GetDNGCATMatrix )
     int ret = rawProcessor.open_file( ( pathToRaw.string() ).c_str() );
     ret     = rawProcessor.unpack();
 
-    DNGIdt *di           = new DNGIdt( rawProcessor.imgdata.rawdata );
+    Metadata metadata;
+    init_metadata( rawProcessor, metadata );
+    DNGIdt *di           = new DNGIdt( metadata );
     double  matrix[3][3] = { { 0.9907763427, -0.0022862289, 0.0209908807 },
                              { -0.0017882434, 0.9941341374, 0.0083008330 },
                              { 0.0003777587, 0.0015609315, 1.1063201101 } };
@@ -170,7 +220,9 @@ BOOST_AUTO_TEST_CASE( TestIDT_GetDNGIDTMatrix )
     int ret = rawProcessor.open_file( ( pathToRaw.string() ).c_str() );
     ret     = rawProcessor.unpack();
 
-    DNGIdt *di           = new DNGIdt( rawProcessor.imgdata.rawdata );
+    Metadata metadata;
+    init_metadata( rawProcessor, metadata );
+    DNGIdt *di           = new DNGIdt( metadata );
     double  matrix[3][3] = { { 1.0536466144, 0.0039044182, 0.0049084502 },
                              { -0.4899562165, 1.3614787986, 0.1020844728 },
                              { -0.0024498461, 0.0060497128, 1.0139159537 } };

--- a/unittest/testIDT.cpp
+++ b/unittest/testIDT.cpp
@@ -16,6 +16,7 @@
 
 using namespace std;
 using namespace rta;
+using namespace rta::core;
 
 #define DATA_PATH "../_deps/rawtoaces_data-src/data/"
 

--- a/unittest/testIllum.cpp
+++ b/unittest/testIllum.cpp
@@ -18,6 +18,7 @@
 
 using namespace std;
 using namespace rta;
+using namespace rta::core;
 
 BOOST_AUTO_TEST_CASE( TestIllum_DefaultConstructor )
 {

--- a/unittest/testSpst.cpp
+++ b/unittest/testSpst.cpp
@@ -18,6 +18,7 @@
 
 using namespace std;
 using namespace rta;
+using namespace rta::core;
 
 BOOST_AUTO_TEST_CASE( TestSpst_DefaultConstructor )
 {


### PR DESCRIPTION
This removes the libraw data structure being passed to the core library and replaces it with a dedicated structure rta::core::Metadata.

This changes the public interface, so is not backward compatible with v1.x, has to be a major update.