### PR TITLE
fix CI broken on aswf-2024+ images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,13 @@ jobs:
           - desc: gcc11
             nametag: linux-vfx2024
             os: ubuntu-latest
-            container: aswf/ci-osl:2024-clang17
+            container: aswf/ci-osl:2024-clang17.2
             vfxyear: 2024
             cxx_std: 17
           - desc: clang17
             nametag: linux-vfx2024-clang17
             os: ubuntu-latest
-            container: aswf/ci-osl:2024-clang17
+            container: aswf/ci-osl:2024-clang17.2
             vfxyear: 2024
             cc_compiler: clang
             cxx_compiler: clang++


### PR DESCRIPTION
The 2024 and later versions of ASWF CI runners come with 2 versions of libraw pre-installed, which causes linking errors. Locking in the working version of the runner so we have a working CI for now. 