### PR TITLE
v2 - install to /usr/local/share, not /usrl/local/include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,13 +117,13 @@ if ( APPLE OR UNIX )
     install (
         DIRECTORY
             ${PROJECT_BINARY_DIR}/_deps/rawtoaces_data-src/data
-        DESTINATION include/rawtoaces
+        DESTINATION share/rawtoaces
     )
     
     install (
         FILES
             ${PROJECT_BINARY_DIR}/_deps/rawtoaces_data-src/LICENSE
-        DESTINATION include/rawtoaces/data
+        DESTINATION share/rawtoaces/data
     )
 endif()
 

--- a/src/rawtoaces_util/acesrender.cpp
+++ b/src/rawtoaces_util/acesrender.cpp
@@ -108,8 +108,10 @@ std::vector<std::string> database_paths()
     const std::string separator    = ";";
     const std::string default_path = ".";
 #else
-    char              separator    = ':';
-    const std::string default_path = "/usr/local/share/rawtoaces/data";
+    char              separator = ':';
+    const std::string default_path =
+        "/usr/local/share/rawtoaces/data"
+        ":/usr/local/include/rawtoaces/data"; // Old path for back compatibility
 #endif
 
     std::string path;


### PR DESCRIPTION
Install the data files to `/usr/local/share`, not to `/usr/local/include`
Not backwards compatible