### PR TITLE
Kill unused math functions and formatting cleanup

### DIFF
--- a/tests/testMath.cpp
+++ b/tests/testMath.cpp
@@ -13,30 +13,6 @@
 
 using namespace rta::core;
 
-void test_InvertD()
-{
-    double a = 1.0;
-    OIIO_CHECK_EQUAL_THRESH( invertD( a ), 1.0, 1e-9 );
-
-    double b = 1000.0;
-    OIIO_CHECK_EQUAL_THRESH( invertD( b ), 0.001, 1e-9 );
-
-    double c = 1000000.0;
-    OIIO_CHECK_EQUAL_THRESH( invertD( c ), 0.000001, 1e-9 );
-};
-
-void test_Clip()
-{
-    double a = 254.9;
-    OIIO_CHECK_EQUAL_THRESH( clip( a, 255.0 ), a, 1e-5 );
-
-    double b = 255.1;
-    OIIO_CHECK_EQUAL_THRESH( clip( b, 255.0 ), 255.0, 1e-5 );
-
-    double c = 63355.0;
-    OIIO_CHECK_EQUAL_THRESH( clip( c, 63355.0 ), c, 1e-5 );
-};
-
 void test_IsSquare()
 {
     vector<vector<double>> a;
@@ -126,24 +102,6 @@ void test_InvertV()
     FORI( 9 ) OIIO_CHECK_EQUAL_THRESH( V_Inverse[i], MV_Inverse[i], 1e-5 );
 };
 
-void test_DiagVM()
-{
-    double M[3][3] = { { 1.0, 0.0, 0.0 },
-                       { 0.0, 2.0, 0.0 },
-                       { 0.0, 0.0, 3.0 } };
-
-    double                 vd[3] = { 1.0, 2.0, 3.0 };
-    vector<double>         MV( vd, vd + 3 );
-    vector<vector<double>> MVD = diagVM( MV );
-
-    FORI( 3 )
-    {
-        OIIO_CHECK_EQUAL_THRESH( MVD[i][0], M[i][0], 1e-5 );
-        OIIO_CHECK_EQUAL_THRESH( MVD[i][1], M[i][1], 1e-5 );
-        OIIO_CHECK_EQUAL_THRESH( MVD[i][2], M[i][2], 1e-5 );
-    }
-};
-
 void test_DiagV()
 {
     double         v[3]  = { 1.0, 2.0, 3.0 };
@@ -200,41 +158,6 @@ void test_SumVector()
     OIIO_CHECK_EQUAL_THRESH( sum, 55.0000, 1e-5 );
 };
 
-void test_ScaleVectorMax()
-{
-    double M[10]        = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
-    double M_Scaled[10] = { 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0 };
-    vector<double> MV( M, M + 10 );
-
-    scale_vector_max( MV );
-    FORI( MV.size() )
-    OIIO_CHECK_EQUAL_THRESH( M_Scaled[i], MV[i], 1e-5 );
-};
-
-void test_ScaleVectorMin()
-{
-    double M[10] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
-    vector<double> MV( M, M + 10 );
-
-    scale_vector_min( MV );
-    FORI( MV.size() )
-    OIIO_CHECK_EQUAL_THRESH( M[i], MV[i], 1e-5 );
-};
-
-void test_scaleVectorD()
-{
-    double M[10]        = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
-    double M_Scaled[10] = { 10.0000000000, 5.0000000000, 3.3333333333,
-                            2.5000000000,  2.0000000000, 1.6666666667,
-                            1.4285714286,  1.2500000000, 1.1111111111,
-                            1.0000000000 };
-    vector<double> MV( M, M + 10 );
-
-    scaleVectorD( MV );
-    FORI( MV.size() )
-    OIIO_CHECK_EQUAL_THRESH( MV[i], M_Scaled[i], 1e-5 );
-};
-
 void test_MulVectorElement()
 {
     double M1[10] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
@@ -247,19 +170,6 @@ void test_MulVectorElement()
     vector<double> MV3 = mulVectorElement( MV1, MV2 );
     FORI( MV3.size() )
     OIIO_CHECK_EQUAL_THRESH( MV3[i], 10.0000000000, 1e-5 );
-};
-
-void test_DivVectorElement()
-{
-    double M1[10] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
-    double M2[10] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 };
-
-    vector<double> MV1( M1, M1 + 10 );
-    vector<double> MV2( M2, M2 + 10 );
-
-    vector<double> MV3 = divVectorElement( MV1, MV2 );
-    FORI( MV3.size() )
-    OIIO_CHECK_EQUAL_THRESH( MV3[i], 1.0000000000, 1e-5 );
 };
 
 void test_MulVector1()
@@ -310,61 +220,6 @@ void test_MulVector2()
     vector<double> MV3 = mulVector( MV1, MV2 );
     FORI( 3 )
     OIIO_CHECK_EQUAL_THRESH( MV3[i], M2[i], 1e-5 );
-};
-
-void test_MulVectorArray()
-{
-    double data[9] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
-    double M[3][3] = { { 1.0000000000, 0.1000000000, 0.0100000000 },
-                       { 0.1000000000, 2.0000000000, 0.0100000000 },
-                       { 0.1000000000, 0.0100000000, 3.0000000000 }
-
-    };
-
-    double data_test[9] = { 1.2300000000, 4.13000000000, 9.12000000000,
-                            4.5600000000, 10.4600000000, 18.4500000000,
-                            7.8900000000, 16.7900000000, 27.7800000000 };
-
-    vector<vector<double>> MV( 3, vector<double>( 3 ) );
-    FORIJ( 3, 3 )
-    MV[i][j] = M[i][j];
-
-    mulVectorArray( data, 9, 3, MV );
-    FORI( 9 )
-    OIIO_CHECK_EQUAL_THRESH( data[i], data_test[i], 1e-5 );
-};
-
-void test_SolveVM()
-{
-    double M1[3][3] = { { 1.0000000000, 0.0000000000, 0.0000000000 },
-                        { 0.0000000000, 2.0000000000, 0.0000000000 },
-                        { 0.0000000000, 0.0000000000, 3.0000000000 }
-
-    };
-    double M2[3][3] = { { 1.0000000000, 0.0000000000, 0.0000000000 },
-                        { 0.0000000000, 1.0000000000, 0.0000000000 },
-                        { 0.0000000000, 0.0000000000, 1.0000000000 }
-
-    };
-
-    double M3_test[3][3] = { { 1.0000000000, 0.0000000000, 0.0000000000 },
-                             { 0.0000000000, 0.5000000000, 0.0000000000 },
-                             { 0.0000000000, 0.0000000000, 0.3333333333 }
-
-    };
-
-    vector<vector<double>> MV1( 3, vector<double>( 3 ) );
-    vector<vector<double>> MV2( 3, vector<double>( 3 ) );
-
-    FORIJ( 3, 3 )
-    {
-        MV1[i][j] = M1[i][j];
-        MV2[i][j] = M2[i][j];
-    }
-
-    vector<vector<double>> MV3 = solveVM( MV1, MV2 );
-    FORIJ( 3, 3 )
-    OIIO_CHECK_EQUAL_THRESH( MV3[i][j], M3_test[i][j], 1e-5 );
 };
 
 void test_FindIndexInterp1()
@@ -909,27 +764,18 @@ void test_GetCalcXYZt()
 
 int main( int, char ** )
 {
-    test_InvertD();
-    test_Clip();
     test_IsSquare();
     test_AddVectors();
     test_SubVectors();
     test_Cross2();
     test_InvertVM();
     test_InvertV();
-    test_DiagVM();
     test_DiagV();
     test_TransposeVec();
     test_SumVector();
-    test_ScaleVectorMax();
-    test_ScaleVectorMin();
-    test_scaleVectorD();
     test_MulVectorElement();
-    test_DivVectorElement();
     test_MulVector1();
     test_MulVector2();
-    test_MulVectorArray();
-    test_SolveVM();
     test_FindIndexInterp1();
     test_Interp1DLinear();
     testIDT_XytoXYZ();


### PR DESCRIPTION
- Remove unused math functions: invertD, clip, diagVM, scale_vector_max, scale_vector_min, scaleVectorD, divVectorElement, mulVectorArray, solveVM
- Remove corresponding test functions
- Clean up extra blank lines for better formatting