### PR TITLE
fix: change hardcoded size to set size at runtime

### DIFF
--- a/src/rawtoaces_core/mathOps.h
+++ b/src/rawtoaces_core/mathOps.h
@@ -435,7 +435,8 @@ std::vector<std::vector<T>> calculate_CAT(
 template <typename T>
 vector<vector<T>> XYZ_to_LAB( const vector<vector<T>> &XYZ )
 {
-    assert( XYZ.size() == 190 );
+    assert( !XYZ.empty() );
+    assert( XYZ[0].size() == 3 );
     T add = T( 16.0 / 116.0 );
 
     vector<vector<T>> tmpXYZ( XYZ.size(), vector<T>( 3, T( 1.0 ) ) );
@@ -464,7 +465,7 @@ template <typename T>
 vector<vector<T>>
 getCalcXYZt( const vector<vector<T>> &RGB, const T beta_params[6] )
 {
-    assert( RGB.size() == 190 );
+    assert( !RGB.empty() );
 
     vector<vector<T>> BV( 3, vector<T>( 3 ) );
     vector<vector<T>> M( 3, vector<T>( 3 ) );

--- a/src/rawtoaces_core/rawtoaces_core.cpp
+++ b/src/rawtoaces_core/rawtoaces_core.cpp
@@ -1232,14 +1232,14 @@ vector<vector<double>> MetadataSolver::calculate_IDT_matrix()
 template <typename T>
 bool IDTOptimizationCost::operator()( const T *beta_params, T *residuals ) const
 {
-    vector<vector<T>> RGB_copy( 190, vector<T>( 3 ) );
-    for ( size_t i = 0; i < 190; i++ )
+    vector<vector<T>> RGB_copy( _RGB.size(), vector<T>( 3 ) );
+    for ( size_t i = 0; i < _RGB.size(); i++ )
         for ( size_t j = 0; j < 3; j++ )
             RGB_copy[i][j] = T( _RGB[i][j] );
 
     vector<vector<T>> out_calc_LAB =
         XYZ_to_LAB( getCalcXYZt( RGB_copy, beta_params ) );
-    for ( size_t i = 0; i < 190; i++ )
+    for ( size_t i = 0; i < _RGB.size(); i++ )
         for ( size_t j = 0; j < 3; j++ )
             residuals[i * 3 + j] = _outLAB[i][j] - out_calc_LAB[i][j];
 


### PR DESCRIPTION
Fixes #196

Summary:
- Remove hardcoded training set size; compute from dataset at runtime
- Run clang-format; all tests passing locally (CMake/CTest)

Note:
- No public API changes