### PR TITLE
fix build issues caused by the order of OIIO includes

### DIFF
--- a/tests/test_image_converter.cpp
+++ b/tests/test_image_converter.cpp
@@ -7,6 +7,11 @@
 #    undef RGB
 #endif
 
+#include "../src/rawtoaces_util/rawtoaces_util_priv.h"
+
+// must be before <OpenImageIO/unittest.h>
+#include <rawtoaces/image_converter.h>
+
 #include <OpenImageIO/unittest.h>
 #include <filesystem>
 #include <fstream>
@@ -15,9 +20,6 @@
 #include <vector>
 #include <sys/stat.h> // for mkfifo
 #include <ctime>
-
-#include "../src/rawtoaces_util/rawtoaces_util_priv.h"
-#include <rawtoaces/image_converter.h>
 
 using namespace rta::util;
 

--- a/tests/usage_example_util.cpp
+++ b/tests/usage_example_util.cpp
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the rawtoaces Project.
 
+// must be before <OpenImageIO/unittest.h>
+#include <rawtoaces/image_converter.h>
+
 #include <filesystem>
 #include <OpenImageIO/unittest.h>
-#include <rawtoaces/image_converter.h>
 
 // This file contains some usage examples of the util library.
 // It has only very little unit test functionality to keep the code clean.


### PR DESCRIPTION
Had some issues on my Mac with unresolved templates in OIIO. Didn't look much into that, moving the <OpenImageIO/unittest.h> after other headers including the OIIO bits seems to fix that.