### PR TITLE
exclude python and nanobind files from static analysis

### DIFF
--- a/tests/static_analysis/codechecker_skipfile.txt
+++ b/tests/static_analysis/codechecker_skipfile.txt
@@ -1,3 +1,5 @@
 # The paths are based on Ubuntu builds
 -/usr/include/OpenImageIO/detail/fmt/format.h
 -/usr/lib/llvm-22/lib/clang/22/include/cetintrin.h
+-/usr/share/nanobind/*
+-/usr/include/python*


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

the python and nanobind headers and source files trigger static analysis errors, adding them to the ignore list.

## Tests

none needed


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
