### PR TITLE
add native rawtoaces CI runners

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: |
           conan profile detect --force
-          conan install . --output-folder=build_deps --build=missing
+          conan install --requires=nlohmann_json/3.12.0 --requires=nanobind/2.9.2 --generator CMakeDeps --generator CMakeToolchain --output-folder=build_deps --build=missing
           python -m pip install pytest
     
       - name: Configure CMake

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,7 +1,0 @@
-[requires]
-nlohmann_json/3.12.0
-nanobind/2.9.2
-
-[generators]
-CMakeDeps
-CMakeToolchain


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Add native CI runners (aswf/ci-rawtoaces) for VFX year 2024, 2025, 2026.

## Tests

No changes to the code


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
