### PR TITLE
fix macos CI

### DIFF
--- a/build_scripts/install_deps_mac.bash
+++ b/build_scripts/install_deps_mac.bash
@@ -2,6 +2,8 @@
 
 set -ex
 
+brew update
+
 brew install ceres-solver nlohmann-json openimageio nanobind robin-map
 
 python3 -m pip install --break-system-packages pytest


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

The macos CI runners have been updated to Eigen 5.0.1, which is incompatible with Ceres 2.2.0_3.
Calling `brew update` prior to installing Ceres bumps its version to 2.2.0_4, which fixes the build.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
