### PR TITLE
[fix] remove breaking const qualifier on hints in configure

### DIFF
--- a/include/rawtoaces/image_converter.h
+++ b/include/rawtoaces/image_converter.h
@@ -160,14 +160,14 @@ public:
     /// decode the pixels.
     /// @param input_filename
     ///    A file name of the raw image file to read the metadata from.
-    /// @param hints
+    /// @param options
     ///    Conversion hints to be passed to OIIO when reading an image file.
     ///    The list can be pre- or post- updated with other hints, unrelated to
     ///    the rawtoaces conversion.
     /// @result
     ///    `true` if configured successfully.
     bool configure(
-        const std::string &input_filename, const OIIO::ParamValueList &hints );
+        const std::string &input_filename, OIIO::ParamValueList &options );
 
     /// Configures the converter using the requested white balance and colour
     /// matrix method, and the metadata of the given OIIO::ImageSpec object.
@@ -175,14 +175,14 @@ public:
     /// on disk operations.
     /// @param imageSpec
     ///    An image spec obtained from OIIO::ImageInput or OIIO::ImageBuf.
-    /// @param hints
+    /// @param options
     ///    Conversion hints to be passed to OIIO when reading an image file.
     ///    The list can be pre- or post- updated with other hints, unrelated to
     ///    the rawtoaces conversion.
     /// @result
     ///    `true` if configured successfully.
     bool configure(
-        const OIIO::ImageSpec &imageSpec, const OIIO::ParamValueList &hints );
+        const OIIO::ImageSpec &imageSpec, OIIO::ParamValueList &options );
 
     /// Load an image from a given `path` into a `buffer` using the `hints`
     /// calculated by the `configure` method. The hints can be manually

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -1239,9 +1239,8 @@ void fix_metadata( OIIO::ImageSpec &spec )
 }
 
 bool ImageConverter::configure(
-    const std::string &input_filename, const OIIO::ParamValueList &hints = {} )
+    const std::string &input_filename, OIIO::ParamValueList &options )
 {
-    OIIO::ParamValueList options = hints;
     options["raw:ColorSpace"]    = "XYZ";
     options["raw:use_camera_wb"] = 0;
     options["raw:use_auto_wb"]   = 0;
@@ -1275,9 +1274,8 @@ bool ImageConverter::configure(
 // -G - green_matching() filter
 
 bool ImageConverter::configure(
-    const OIIO::ImageSpec &image_spec, const OIIO::ParamValueList &hints = {} )
+    const OIIO::ImageSpec &image_spec, OIIO::ParamValueList &options )
 {
-    OIIO::ParamValueList options = hints;
     options["raw:use_camera_wb"] = 0;
     options["raw:use_auto_wb"]   = 0;
 


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

The const qualifier on hints added in [215](https://github.com/AcademySoftwareFoundation/rawtoaces/pull/215) breaks conversion. Rolling that change back.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
