### PR TITLE
fix: improve log output consistency at different verbosity levels

### DIFF
--- a/include/rawtoaces/log.h
+++ b/include/rawtoaces/log.h
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the rawtoaces Project.
+
+#ifndef RAWTOACES_LOG_H
+#define RAWTOACES_LOG_H
+
+#include <iostream>
+#include <string>
+
+namespace rta
+{
+
+/// Log levels for rawtoaces output
+/// Each level includes all messages from lower levels
+enum class LogLevel
+{
+    Silent = 0,  ///< No output except errors
+    Error = 1,   ///< Error messages only
+    Warning = 2, ///< Warnings and errors
+    Info = 3,    ///< Basic progress information (default for -v)
+    Debug = 4,   ///< Detailed configuration and processing info (-v -v)
+    Trace = 5    ///< Very detailed output including matrices (-v -v -v)
+};
+
+/// Simple logging utility for consistent output formatting
+class Log
+{
+  public:
+    /// Get the singleton instance
+    static Log &instance()
+    {
+        static Log log;
+        return log;
+    }
+
+    /// Set the current verbosity level (0-5)
+    void set_verbosity( int level )
+    {
+        if ( level <= 0 )
+            _level = LogLevel::Silent;
+        else if ( level == 1 )
+            _level = LogLevel::Info;
+        else if ( level == 2 )
+            _level = LogLevel::Debug;
+        else
+            _level = LogLevel::Trace;
+    }
+
+    /// Get the current verbosity level as integer
+    int get_verbosity() const { return static_cast<int>( _level ); }
+
+    /// Check if a given level should be logged
+    bool should_log( LogLevel level ) const { return level <= _level; }
+
+    /// Log an error message (always shown unless Silent)
+    template <typename... Args> void error( Args &&...args )
+    {
+        if ( _level >= LogLevel::Error )
+        {
+            std::cerr << "[ERROR] ";
+            ( std::cerr << ... << args ) << std::endl;
+        }
+    }
+
+    /// Log a warning message
+    template <typename... Args> void warning( Args &&...args )
+    {
+        if ( _level >= LogLevel::Warning )
+        {
+            std::cerr << "[WARNING] ";
+            ( std::cerr << ... << args ) << std::endl;
+        }
+    }
+
+    /// Log an info message (basic progress, -v)
+    template <typename... Args> void info( Args &&...args )
+    {
+        if ( _level >= LogLevel::Info )
+        {
+            std::cerr << "[INFO] ";
+            ( std::cerr << ... << args ) << std::endl;
+        }
+    }
+
+    /// Log a debug message (detailed info, -v -v)
+    template <typename... Args> void debug( Args &&...args )
+    {
+        if ( _level >= LogLevel::Debug )
+        {
+            std::cerr << "[DEBUG] ";
+            ( std::cerr << ... << args ) << std::endl;
+        }
+    }
+
+    /// Log a trace message (very detailed, -v -v -v)
+    template <typename... Args> void trace( Args &&...args )
+    {
+        if ( _level >= LogLevel::Trace )
+        {
+            std::cerr << "[TRACE] ";
+            ( std::cerr << ... << args ) << std::endl;
+        }
+    }
+
+    /// Log a message without prefix (for continuation or special formatting)
+    template <typename... Args> void raw( LogLevel level, Args &&...args )
+    {
+        if ( _level >= level )
+        {
+            ( std::cerr << ... << args );
+        }
+    }
+
+    /// Log a newline
+    void newline( LogLevel level = LogLevel::Info )
+    {
+        if ( _level >= level )
+        {
+            std::cerr << std::endl;
+        }
+    }
+
+private:
+    Log() : _level( LogLevel::Warning ) {} // Default: show warnings and errors
+    LogLevel _level;
+};
+
+/// Convenience macro for getting the logger
+#define RTA_LOG rta::Log::instance()
+
+} // namespace rta
+
+#endif // RAWTOACES_LOG_H

--- a/src/rawtoaces/main.cpp
+++ b/src/rawtoaces/main.cpp
@@ -2,6 +2,7 @@
 // Copyright Contributors to the rawtoaces Project.
 
 #include <rawtoaces/image_converter.h>
+#include <rawtoaces/log.h>
 
 #include <set>
 
@@ -25,6 +26,9 @@ int main( int argc, const char *argv[] )
     {
         return 1;
     }
+
+    // Sync logger verbosity with converter settings
+    RTA_LOG.set_verbosity( converter.settings.verbosity );
 
     auto files = arg_parser["filename"].as_vec<std::string>();
     if ( files.empty() || ( files.size() == 1 && files[0] == "" ) )
@@ -52,14 +56,20 @@ int main( int argc, const char *argv[] )
         for ( auto const &input_filename: batch )
         {
             ++file_index;
-            std::cout << "[" << file_index << "/" << total_files
-                      << "] Processing file: " << input_filename << std::endl;
+
+            // Progress output respects verbosity - shown at info level (1+)
+            if ( converter.settings.verbosity > 0 )
+            {
+                std::cout << "[" << file_index << "/" << total_files
+                          << "] Processing file: " << input_filename
+                          << std::endl;
+            }
 
             empty  = false;
             result = converter.process_image( input_filename );
             if ( !result )
             {
-                std::cerr << "Failed on file [" << file_index << "/"
+                std::cerr << "[ERROR] Failed on file [" << file_index << "/"
                           << total_files << "]: " << input_filename
                           << std::endl;
                 break;

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -2,6 +2,7 @@
 // Copyright Contributors to the rawtoaces Project.
 
 #include <rawtoaces/image_converter.h>
+#include <rawtoaces/log.h>
 #include <rawtoaces/rawtoaces_core.h>
 #include <rawtoaces/usage_timer.h>
 
@@ -344,8 +345,8 @@ bool prepare_transform_spectral(
 
         if ( settings.verbosity > 0 )
         {
-            std::cerr << "Found illuminant: '" << solver.illuminant.type << "'."
-                      << std::endl;
+            std::cerr << "[INFO] Found illuminant: '" << solver.illuminant.type
+                      << "'." << std::endl;
         }
     }
     else
@@ -364,7 +365,7 @@ bool prepare_transform_spectral(
 
         if ( settings.verbosity > 0 )
         {
-            std::cerr << "White balance coefficients:" << std::endl;
+            std::cerr << "[INFO] White balance coefficients: ";
             for ( auto &wb_multiplier: WB_multipliers )
             {
                 std::cerr << wb_multiplier << " ";
@@ -384,9 +385,10 @@ bool prepare_transform_spectral(
 
     IDT_matrix = solver.get_IDT_matrix();
 
-    if ( settings.verbosity > 0 )
+    if ( settings.verbosity > 1 )
     {
-        std::cerr << "Input Device Transform (IDT) matrix:" << std::endl;
+        std::cerr << "[DEBUG] Input Device Transform (IDT) matrix:"
+                  << std::endl;
         for ( auto &row: IDT_matrix )
         {
             std::cerr << "  ";
@@ -494,11 +496,12 @@ bool prepare_transform_DNG(
     core::MetadataSolver solver( metadata );
     IDT_matrix = solver.calculate_IDT_matrix();
 
-    if ( settings.verbosity > 0 )
+    if ( settings.verbosity > 1 )
     {
-        std::cerr << "Input transform matrix:" << std::endl;
+        std::cerr << "[DEBUG] Input transform matrix (DNG):" << std::endl;
         for ( auto &IDT_matrix_row: IDT_matrix )
         {
+            std::cerr << "  ";
             for ( auto &IDT_matrix_row_element: IDT_matrix_row )
             {
                 std::cerr << IDT_matrix_row_element << " ";
@@ -884,7 +887,8 @@ void ImageConverter::init_parser( OIIO::ArgParse &arg_parser )
     arg_parser.arg( "--verbose" )
         .help(
             "(-v) Print progress messages. "
-            "Repeat -v to increase verbosity (e.g. -v -v, -v -v -v)." )
+            "Use -v for basic progress, -v -v for detailed config, "
+            "-v -v -v for trace output including matrices." )
         .action( [&]( OIIO::cspan<const char *> /* argv */ ) {
             settings.verbosity++;
         } );
@@ -1398,7 +1402,7 @@ bool ImageConverter::configure(
             matrix_method = Settings::MatrixMethod::Metadata;
             if ( settings.verbosity > 0 )
             {
-                std::cerr << "Info: Falling back to metadata matrix method "
+                std::cerr << "[INFO] Falling back to metadata matrix method "
                           << "because no spectral data was found for camera "
                           << static_cast<std::string>( camera_identifier )
                           << std::endl;
@@ -1506,7 +1510,7 @@ bool ImageConverter::configure(
 
     if ( settings.verbosity > 1 )
     {
-        std::cerr << "Configuration:" << std::endl;
+        std::cerr << "[DEBUG] Configuration:" << std::endl;
 
         std::cerr << "  WB method: ";
         switch ( settings.WB_method )
@@ -1888,7 +1892,7 @@ bool ImageConverter::process_image( const std::string &input_filename )
     // ___ Configure transform ___
     if ( settings.verbosity > 0 )
     {
-        std::cerr << "Configuring transform for: " << input_filename
+        std::cerr << "[INFO] Configuring transform for: " << input_filename
                   << std::endl;
     }
     usage_timer.reset();
@@ -1904,7 +1908,7 @@ bool ImageConverter::process_image( const std::string &input_filename )
     // ___ Load image ___
     if ( settings.verbosity > 0 )
     {
-        std::cerr << "Loading image: " << input_filename << std::endl;
+        std::cerr << "[INFO] Loading image: " << input_filename << std::endl;
     }
     usage_timer.reset();
     OIIO::ImageBuf buffer;
@@ -1918,7 +1922,7 @@ bool ImageConverter::process_image( const std::string &input_filename )
     // ___ Apply matrix/matrices ___
     if ( settings.verbosity > 0 )
     {
-        std::cerr << "Applying transform matrix" << std::endl;
+        std::cerr << "[INFO] Applying transform matrix" << std::endl;
     }
     usage_timer.reset();
     if ( !apply_matrix( buffer, buffer ) )
@@ -1932,7 +1936,7 @@ bool ImageConverter::process_image( const std::string &input_filename )
     // ___ Apply scale ___
     if ( settings.verbosity > 0 )
     {
-        std::cerr << "Applying scale" << std::endl;
+        std::cerr << "[INFO] Applying scale" << std::endl;
     }
     usage_timer.reset();
     if ( !apply_scale( buffer, buffer ) )
@@ -1946,7 +1950,7 @@ bool ImageConverter::process_image( const std::string &input_filename )
     // ___ Apply crop ___
     if ( settings.verbosity > 0 )
     {
-        std::cerr << "Applying crop" << std::endl;
+        std::cerr << "[INFO] Applying crop" << std::endl;
     }
     usage_timer.reset();
     if ( !apply_crop( buffer, buffer ) )
@@ -1960,7 +1964,7 @@ bool ImageConverter::process_image( const std::string &input_filename )
     // ___ Save image ___
     if ( settings.verbosity > 0 )
     {
-        std::cerr << "Saving output: " << output_filename << std::endl;
+        std::cerr << "[INFO] Saving output: " << output_filename << std::endl;
     }
     usage_timer.reset();
     if ( !save_image( output_filename, buffer ) )


### PR DESCRIPTION
- Add log.h header with Log class for consistent logging with level prefixes
- Update main.cpp to respect verbosity for progress output
- Add [INFO], [DEBUG], [ERROR] prefixes to all log messages
- Move matrix output to verbosity level 2 (debug) instead of level 1
- Update --verbose help text to explain verbosity levels:
  - -v: basic progress (INFO level)
  - -v -v: detailed config (DEBUG level)
  - -v -v -v: trace output including matrices (TRACE level)

Fixes #177

<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

<!-- Please provide a description of what this PR is meant to fix, and  -->
<!-- how it works (if it's not going to be very clear from the code).   -->

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [ ] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
