### PR TITLE
[analysis] fix warnings

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -8,9 +8,9 @@ permissions:
 on:
   schedule:
     # Run nightly
-    - cron: "0 8 * * *"
+#    - cron: "0 8 * * *"
     # Run weekly
-    # - cron: "0 0 * * 0"
+     - cron: "0 0 * * 0"
   push:
     # Run on pushes only to main or if the branch name contains "analysis"
     branches:
@@ -52,6 +52,11 @@ jobs:
         shell: bash
         run: |
           build_scripts/install_deps_linux.bash
+          
+      - name: Install cppcheck
+        shell: bash
+        run: |
+          sudo apt-get -q -f install -y cppcheck
       
       - name: Configure CMake
         run: >

--- a/include/rawtoaces/rawtoaces_core.h
+++ b/include/rawtoaces/rawtoaces_core.h
@@ -12,18 +12,24 @@ namespace core
 
 // clang-format off
 
+// NOLINTBEGIN
+/// Deprecated, not currently used and will be removed in v3.0.
 static const std::vector<std::vector<double>> XYZ_to_ACES = {
     {  1.0498110175, 0.0000000000, -0.0000974845 },
     { -0.4959030231, 1.3733130458,  0.0982400361 },
     {  0.0000000000, 0.0000000000,  0.9912520182 }
 };
+// NOLINTEND
 
+// NOLINTBEGIN
 /// Colour adaptation from D65 to the ACES white point
+/// Deprecated, not currently used and will be removed in v3.0.
 static const std::vector<std::vector<double> > CAT_D65_to_ACES = {
     {  1.0097583639200136,      0.0050178093846550455, -0.015058389092388141  },
     {  0.0036602813378778347,   1.0030138169214682,    -0.0059802329456399824 },
     { -0.00029980928869024906, -0.0010516909063249997,  0.92820279627476576   }
 };
+// NOLINTEND
 
 // clang-format on
 

--- a/src/rawtoaces_core/define.h
+++ b/src/rawtoaces_core/define.h
@@ -221,19 +221,6 @@ static const double bradford[3][3] = {
     { 0.0389, -0.0685,  1.0296}
 };
 
-//  Color Adaptation Matrices - CAT02 (default)
-static const std::vector<std::vector<double>> CAT02 = {
-    {  0.7328, 0.4296, -0.1624 },
-    { -0.7036, 1.6975,  0.0061 },
-    {  0.0030, 0.0136,  0.9834 }
-};
-
-static const std::vector<std::vector<double>> CAT02_inv = {
-    {  1.0961238208355142,    -0.27886900021828726,   0.18274517938277304 },
-    {  0.45436904197535921,    0.47353315430741177,   0.072097803717229125 },
-    { -0.0096276087384293551, -0.0056980312161134198, 1.0153256399545427 }
-};
-
 // clang-format on
 
 // Function to Open Directories

--- a/src/rawtoaces_core/mathOps.h
+++ b/src/rawtoaces_core/mathOps.h
@@ -419,6 +419,21 @@ std::vector<std::vector<T>> calculate_CAT(
     assert( src_white_XYZ.size() == 3 );
     assert( dst_white_XYZ.size() == 3 );
 
+    // clang-format off
+    // Color Adaptation Matrices - CAT02 (default)
+    static const std::vector<std::vector<double>> CAT02 = {
+        {  0.7328, 0.4296, -0.1624 },
+        { -0.7036, 1.6975,  0.0061 },
+        {  0.0030, 0.0136,  0.9834 }
+    };
+    
+    static const std::vector<std::vector<double>> CAT02_inv = {
+        {  1.0961238208355142,    -0.27886900021828726,   0.18274517938277304 },
+        {  0.45436904197535921,    0.47353315430741177,   0.072097803717229125 },
+        { -0.0096276087384293551, -0.0056980312161134198, 1.0153256399545427 }
+    };
+    // clang-format on
+
     std::vector<double> src_white_LMS = mulVector( src_white_XYZ, CAT02 );
     std::vector<double> dst_white_LMS = mulVector( dst_white_XYZ, CAT02 );
 

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -520,7 +520,16 @@ void prepare_transform_nonDNG(
     // Do not apply IDT for non-DNG
     IDT_matrix.resize( 0 );
 
-    CAT_matrix = rta::core::CAT_D65_to_ACES;
+    // clang-format off
+    // Colour adaptation from D65 to the ACES white point
+    static const std::vector<std::vector<double> > CAT_D65_to_ACES = {
+        {  1.0097583639200136,      0.0050178093846550455, -0.015058389092388141  },
+        {  0.0036602813378778347,   1.0030138169214682,    -0.0059802329456399824 },
+        { -0.00029980928869024906, -0.0010516909063249997,  0.92820279627476576   }
+    };
+    // clang-format on
+
+    CAT_matrix = CAT_D65_to_ACES;
 }
 
 const char *HelpString =
@@ -1676,7 +1685,15 @@ bool ImageConverter::apply_matrix(
         if ( !success )
             return false;
 
-        success = rta::util::apply_matrix( core::XYZ_to_ACES, dst, dst, roi );
+        // clang-format off
+        static const std::vector<std::vector<double>> XYZ_to_ACES = {
+            {  1.0498110175, 0.0000000000, -0.0000974845 },
+            { -0.4959030231, 1.3733130458,  0.0982400361 },
+            {  0.0000000000, 0.0000000000,  0.9912520182 }
+        };
+        // clang-format on
+
+        success = rta::util::apply_matrix( XYZ_to_ACES, dst, dst, roi );
         if ( !success )
             return false;
     }

--- a/tests/static_analysis/codechecker_skipfile.txt
+++ b/tests/static_analysis/codechecker_skipfile.txt
@@ -1,4 +1,5 @@
 # The paths are based on Ubuntu builds
+-*/tests/*
 -/usr/include/OpenImageIO/detail/fmt/format.h
 -/usr/lib/llvm-22/lib/clang/22/include/cetintrin.h
 -/usr/share/nanobind/*


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

The static analyser was showing warnings about four matrices. Those were constructed as global static vectors. Being a global object, the constructor gets called during the app initialisation, not client code, so in case of an exception in the constructor it would be impossible to catch. Since each of the matrices being used in exactly one place, I just moved them closer to the code using them, so the static objects getting initialised in the client code.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
