### PR TITLE
do not use lock file as part of a cache key

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           path: C:/vcpkg/binary-cache
           key: |
-            vcpkg-binary-cache-${{ runner.os }}-${{ hashFiles('build_scripts/vcpkg.json') }}-${{ hashFiles('build_scripts/vcpkg.json.lock') }}
+            vcpkg-binary-cache-${{ runner.os }}-${{ hashFiles('build_scripts/vcpkg.json') }}
           restore-keys: |
             vcpkg-binary-cache-${{ runner.os }}-
             

--- a/build_scripts/install_deps_windows.bash
+++ b/build_scripts/install_deps_windows.bash
@@ -6,10 +6,8 @@ set -ex
 # This allows vcpkg to automatically reuse pre-built packages from cache
 export VCPKG_BINARY_SOURCES="clear;files,C:/vcpkg/binary-cache,readwrite"
 
-# Add/update baseline in vcpkg.json
-vcpkg x-update-baseline \
-    --add-initial-baseline \
-    --x-manifest-root="./build_scripts"
+# Baseline is pinned in vcpkg.json. The latest hash can be found with:
+#   git ls-remote https://github.com/microsoft/vcpkg HEAD | cut -f1
 
 # Install dependencies - vcpkg will automatically use binary cache if available
 vcpkg install \

--- a/build_scripts/vcpkg.json
+++ b/build_scripts/vcpkg.json
@@ -1,5 +1,6 @@
 
 {
+    "builtin-baseline": "2b6a882f61eaa764ec3cf816e2265fe804a44cd0",
     "dependencies": [
         "ceres",
         "nlohmann-json",


### PR DESCRIPTION
I assume we are ok with hardcoding baseline. This gives us a bit of stability. Otherwise all the dependencies will be updating on their on randomly every build. Also makes caching stable.