### PR TITLE
Fix default orientation and box white balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ A help message with a description of all command line options can be obtained by
         --highlight-mode VAL            0 = clip, 1 = unclip, 2 = blend, 3..9 = rebuild. (default: 0)
         --crop-box X Y W H              Apply custom crop. If not present, the default crop is applied, which should match the crop of the in-camera JPEG.
         --crop-mode STR                 Cropping mode. Supported options: 'none' (write out the full sensor area), 'soft' (write out full image, mark the crop as the display window), 'hard' (write out only the crop area). (default: soft)
-        --flip VAL                      If not 0, override the orientation specified in the metadata. 1..8 correspond to EXIF orientation codes (3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.) (default: 0)
+        --flip VAL                      If not -1, override the orientation specified in the metadata. 1..8 correspond to EXIF orientation codes (0 = none, 3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.) (default: -1)
         --denoise-threshold VAL         Wavelet denoising threshold (default: 0)
         --demosaic STR                  Demosaicing algorithm. Supported options: 'linear', 'VNG', 'PPG', 'AHD', 'DCB', 'AHD-Mod', 'AFD', 'VCD', 'Mixed', 'LMMSE', 'AMaZE', 'DHT', 'AAHD', 'AHD'. (default: AHD)
     Benchmarking and debugging:

--- a/include/rawtoaces/image_converter.h
+++ b/include/rawtoaces/image_converter.h
@@ -188,10 +188,10 @@ public:
         /// 0 = clip, 1 = unclip, 2 = blend, 3..9 = rebuild.
         int highlight_mode = 0;
 
-        /// If not 0, override the orientation specified in the metadata.
+        /// If not -1, override the orientation specified in the metadata.
         /// 1..8 correspond to EXIF orientation codes
-        /// (3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.)
-        int flip = 0;
+        /// (0 = none, 3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.)
+        int flip = -1;
 
         /// Apply custom crop. If not specified (all values are zeroes),
         /// the default crop is applied, which should match the crop of the

--- a/src/docs/api/python/image_converter.rst
+++ b/src/docs/api/python/image_converter.rst
@@ -121,9 +121,9 @@ ImageConverter
 
     .. py:attribute:: int flip
 
-      If not 0, override the orientation specified in the metadata.
+      If not -1, override the orientation specified in the metadata.
       1..8 correspond to EXIF orientation codes
-      (3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.)
+      (0 = none, 3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.)
 
     .. py:attribute:: float denoise_threshold
 

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -1006,11 +1006,11 @@ void ImageConverter::init_parser( OIIO::ArgParse &arg_parser )
 
     arg_parser.arg( "--flip" )
         .help(
-            "If not 0, override the orientation specified in the metadata. "
+            "If not -1, override the orientation specified in the metadata. "
             "1..8 correspond to EXIF orientation codes "
-            "(3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.)" )
+            "(0 = none, 3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.)" )
         .metavar( "VAL" )
-        .defaultval( 0 )
+        .defaultval( -1 )
         .action( OIIO::ArgParse::store<int>() );
 
     arg_parser.arg( "--denoise-threshold" )

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -1979,12 +1979,9 @@ bool ImageConverter::configure(
             bool is_empty_box = settings.WB_box[2] == 0 ||
                                 settings.WB_box[3] == 0;
 
-            if ( is_empty_box )
-            {
-                // use whole image (auto white balancing)
-                options["raw:use_auto_wb"] = 1;
-            }
-            else
+            options["raw:use_auto_wb"] = 1;
+
+            if ( !is_empty_box )
             {
                 int32_t WB_box[4];
                 for ( int i = 0; i < 4; i++ )


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Proposing the follow minor changes:
* Change the --flip default value from 0 to -1, meaning it will follow the metadata instead of disabling the flip (0 means none), see https://github.com/LibRaw/LibRaw/blob/master/doc/API-datastruct.html#L740
* Pass use_auto_wb = 1 when using box white balancing method, see https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/src/raw.imageio/rawinput.cpp#L527

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [ ] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
