### PR TITLE
[refactor] implement base class for solvers

### DIFF
--- a/include/rawtoaces/image_converter.h
+++ b/include/rawtoaces/image_converter.h
@@ -456,19 +456,37 @@ public:
     const std::vector<double> &get_WB_multipliers() const;
 
     /// Get the solved input transform matrix of the currently processed image.
-    /// The multipliers become available after calling either of the two
+    /// The matrix becomes available after calling either of the two
     /// `configure` methods.
     /// @result a reference to the matrix.
+    const std::vector<std::vector<double>> &get_transform_matrix() const;
+
+    // clang-format off
+
+    /// Get the solved input transform matrix of the currently processed image.
+    /// The matrix becomes available after calling either of the two
+    /// `configure` methods.
+    /// @result a reference to the matrix.
+    [[deprecated(
+        "This method will be removed in v3. "
+        "Use `get_transform_matrix()`" )]]
     const std::vector<std::vector<double>> &get_IDT_matrix() const;
 
     /// Get the solved chromatic adaptation transform matrix of the currently
-    /// processed image. The multipliers become available after calling either
-    /// of the two `configure` methods.
+    /// processed image.
+    /// The matrix becomes available after calling either of the two
+    /// `configure` methods.
     /// @result a reference to the matrix.
+    [[deprecated(
+        "This method will be removed in v3. "
+        "Use `get_transform_matrix()`" )]]
     const std::vector<std::vector<double>> &get_CAT_matrix() const;
+
+    // clang-format on
 
 private:
     // Solved transform of the current image.
+    std::vector<std::vector<double>> _transform_matrix;
     std::vector<std::vector<double>> _idt_matrix;
     std::vector<std::vector<double>> _cat_matrix;
     std::vector<double>              _wb_multipliers;

--- a/include/rawtoaces/rawtoaces_core.h
+++ b/include/rawtoaces/rawtoaces_core.h
@@ -33,26 +33,60 @@ static const std::vector<std::vector<double> > CAT_D65_to_ACES = {
 
 // clang-format on
 
-/// Calculate spectral power distribution (SPD) of CIE standard daylight illuminant.
-/// The function generates the spectral power distribution for a daylight illuminant
-/// based on the requested correlated color temperature using CIE standard formulas.
+/// Calculate spectral power distribution (SPD) of CIE standard daylight.
+/// illuminant. The function generates the spectral power distribution for a
+/// daylight illuminant based on the requested correlated color temperature
+/// using CIE standard formulas.
 ///
-/// @param cct Correlated colour temperature of the requested illuminant either in Kelvin (in range of 4000-25000), or in short form from an illuminant name, e.g. 55 for D55 (in range of 40-250).
-/// @param spectrum Reference to a `Spectrum` object to fill with the calculated values
+/// @param cct Correlated colour temperature of the requested illuminant either
+/// in Kelvin (in range of 4000-25000), or in short form from an illuminant
+/// name, e.g. 55 for D55 (in range of 40-250).
+/// @param spectrum Reference to a `Spectrum` object to fill with the calculated
+/// values
 /// @pre cct is in valid range for daylight calculations
 void calculate_daylight_SPD( const int &cct, Spectrum &spectrum );
 
-/// Calculate spectral power distribution (SPD) of blackbody radiation at given temperature.
-/// Generates a blackbody curve using Planck's law for the specified correlated color temperature.
-/// The function calculates spectral power distribution across wavelengths defined by Spectrum object.
+/// Calculate spectral power distribution (SPD) of blackbody radiation at given
+/// temperature. Generates a blackbody curve using Planck's law for the
+/// specified correlated color temperature. The function calculates spectral
+/// power distribution across wavelengths defined by Spectrum object.
 ///
-/// @param kelvin Correlated colour temperature of the requested illuminant (1500-3999 Kelvin)
-/// @param spectrum Reference to a `Spectrum` object to fill with the calculated values
+/// @param kelvin Correlated colour temperature of the requested illuminant
+/// (1500-3999 Kelvin)
+/// @param spectrum Reference to a `Spectrum` object to fill with the calculated
+/// values
 /// @pre kelvin is in valid range for blackbody calculations (1500-3999)
 void calculate_blackbody_SPD( const int &kelvin, Spectrum &spectrum );
 
+/// Base class for a colour space transform solver.
+class TransformSolver
+{
+public:
+    /// Initialise the initial state of the solver.
+    /// Sets the `transform_matrix` to an identity matrix and verbosity level
+    /// to zero for silent operation.
+    TransformSolver();
+
+    virtual ~TransformSolver() = default;
+
+    /// Calculate the transform matrix. Each subclass must implement this
+    /// method.
+    /// @return `true` on success.
+    virtual bool calculate_transform() = 0;
+
+    /// The colour transform matrix calculated in `calculate_transform()` gets
+    /// stored here.
+    std::vector<std::vector<double>> transform_matrix;
+
+    /// Error message from the most recent method call that returned false.
+    std::string last_error_message;
+
+    /// Verbosity level.
+    int verbosity;
+};
+
 /// Solve an input transform using spectral sensitivity curves of a camera.
-class SpectralSolver
+class SpectralSolver : public TransformSolver
 {
 public:
     /// The camera spectral data. Can be either assigned directly, loaded
@@ -69,24 +103,28 @@ public:
     /// in-place place via `solver.observer.load()`.
     SpectralData observer;
 
-    /// The training set spectral data. Can be either assigned directly, or loaded
-    /// in-place place via `solver.training_data.load()`.
+    /// The training set spectral data. Can be either assigned directly, or
+    /// loaded in-place place via `solver.training_data.load()`.
     SpectralData training_data;
 
     /// Initialize SpectralSolver with database search path.
-    /// Sets up internal data structures including IDT matrix and white balance multipliers
-    /// with neutral values. Initializes verbosity level to 0 for silent operation.
-    /// Takes the database search path as an optional parameter for finding spectral data files.
+    /// Sets up the initial state of balance multipliers with neutral values.
+    /// Takes the database search path as an optional parameter for finding
+    /// spectral data files.
     ///
-    /// @param search_directories optional database search path for spectral data files
+    /// @param search_directories optional database search path for spectral
+    /// data files
     SpectralSolver( const std::vector<std::string> &search_directories = {} );
 
-    /// A helper method collecting spectral data files of a given type from the database.
-    /// This function searches through the configured search directories to find all
-    /// spectral data files matching the specified type (e.g., "camera", "illuminant").
-    /// It searches for type subdirectories at the top level of each directory and returns JSON files matching the type.
+    /// A helper method collecting spectral data files of a given type from the
+    /// database. This function searches through the configured search
+    /// directories to find all spectral data files matching the specified type
+    /// (e.g., "camera", "illuminant"). It searches for type subdirectories at
+    /// the top level of each directory and returns JSON files matching the
+    /// type.
     ///
-    /// @param type data type of the files to search for (e.g., "camera", "illuminant", "cmf")
+    /// @param type data type of the files to search for (e.g., "camera",
+    /// "illuminant", "cmf")
     /// @return a collection of file paths found in the database
     std::vector<std::string>
     collect_data_files( const std::string &type ) const;
@@ -111,12 +149,14 @@ public:
             &model_aliases ) const;
 
     /// A helper method loading the spectral data for a file at the given path.
-    /// This function loads spectral data from a file, handling both absolute and relative paths.
-    /// For relative paths, it searches through all configured search directories.
+    /// This function loads spectral data from a file, handling both absolute
+    /// and relative paths. For relative paths, it searches through all
+    /// configured search directories.
     ///
     /// @param file_path the path to the file to load. If the path is relative,
     /// all locations in the search path will be searched in.
-    /// @param out_data the `SpectralData` object to be filled with the loaded data.
+    /// @param out_data the `SpectralData` object to be filled with the loaded
+    /// data.
     /// @return `true` if loaded successfully, `false` otherwise
     bool
     load_spectral_data( const std::string &file_path, SpectralData &out_data );
@@ -131,10 +171,10 @@ public:
     /// @return `true` if loaded successfully, `false` otherwise
     bool find_camera( const std::string &make, const std::string &model );
 
-    /// Find spectral power distribution data of an illuminant of the given type.
-    /// This function can handle both built-in illuminant types (e.g., "d55", "3200k")
-    /// and custom illuminants stored in the database. For built-in types, it generates
-    /// the spectral data using standard formulas.
+    /// Find spectral power distribution data of an illuminant of the given
+    /// type. This function can handle both built-in illuminant types (e.g.,
+    /// "d55", "3200k") and custom illuminants stored in the database. For
+    /// built-in types, it generates the spectral data using standard formulas.
     ///
     /// @param type illuminant type. Can be one of the built-in types,
     /// e.g. `d55`, `3200k`, or a custom illuminant stored in the database.
@@ -142,63 +182,85 @@ public:
     bool find_illuminant( const std::string &type );
 
     /// Find the illuminant best matching the given white-balancing multipliers.
-    /// This function analyzes all available illuminants and selects the one that best matches
-    /// the white balance coefficients. It uses Sum of Squared Errors (SSE) to find the
-    /// optimal match and automatically scales the white balance multipliers.
+    /// This function analyzes all available illuminants and selects the one
+    /// that best matches the white balance coefficients. It uses Sum of Squared
+    /// Errors (SSE) to find the optimal match and automatically scales the
+    /// white balance multipliers.
     ///
     /// @param wb_multipliers white-balancing multipliers to match
     /// @return `true` if loaded successfully, `false` otherwise
     bool find_illuminant( const std::vector<double> &wb_multipliers );
 
     /// Calculate the white-balance multipliers for the given configuration.
-    /// This function computes RGB white balance multipliers by integrating camera spectral
-    /// sensitivity with illuminant power spectrum. The multipliers normalize the camera
-    /// response to achieve proper white balance under the specified illuminant conditions.
-    /// The `camera` and `illuminant` data have to be configured prior to this call.
+    /// This function computes RGB white balance multipliers by integrating
+    /// camera spectral sensitivity with illuminant power spectrum. The
+    /// multipliers normalize the camera response to achieve proper white
+    /// balance under the specified illuminant conditions.
+    /// The `camera` and `illuminant` data have to be configured prior to this
+    /// call.
     ///
     /// @return `true` if calculated successfully, `false` otherwise
     /// @pre camera and illuminant data must be properly loaded
     bool calculate_WB();
 
+    // clang-format off
+
     /// Calculate an input transform matrix using curve fitting optimization.
-    /// This function computes the optimal IDT matrix by comparing camera RGB responses
-    /// with target XYZ values across all training patches.
-    /// The `camera`, `illuminant`, `observer` and `training_data` have to be configured prior to this call.
+    /// This function computes the optimal IDT matrix by comparing camera RGB
+    /// responses with target XYZ values across all training patches.
+    /// The `camera`, `illuminant`, `observer` and `training_data` have to be
+    /// configured prior to this call.
     ///
     /// @return `true` if calculated successfully, `false` otherwise
-    /// @pre camera, illuminant, observer, and training_data must be properly loaded
+    /// @pre camera, illuminant, observer, and training_data must be properly
+    /// loaded
+    [[deprecated(
+        "This method will be removed in v3. "
+        "Use `calculate_transform()`" )]]
     bool calculate_IDT_matrix();
 
     /// Get the matrix calculated using `calculate_IDT_matrix()`.
-    /// This function returns a reference to the 3×3 IDT matrix that transforms camera
-    /// RGB values to standardized color space. The matrix is computed by curve fitting
-    /// optimization and represents the optimal color transformation for the camera under
-    /// the specified illuminant conditions.
+    /// This function returns a reference to the 3×3 IDT matrix that transforms
+    /// camera RGB values to standardized color space. The matrix is computed by
+    /// curve fitting optimization and represents the optimal color
+    /// transformation for the camera under the specified illuminant conditions.
     ///
     /// @return a reference to the 3×3 IDT transformation matrix
     /// @pre calculate_IDT_matrix() must have been called successfully
+    [[deprecated(
+        "This method will be removed in v3. "
+        "Use `transform_matrix`" )]]
     const std::vector<std::vector<double>> &get_IDT_matrix() const;
 
-    /// Get the white-balance multipliers calculated using `find_illuminant()` or `calculate_WB()`.
-    /// This function returns a reference to the 3-element vector containing RGB white
-    /// balance multipliers. These multipliers scale the camera response to achieve
-    /// proper white balance under the specified illuminant conditions.
+    // clang-format on
+
+    /// Get the white-balance multipliers calculated using `find_illuminant()`
+    /// or `calculate_WB()`. This function returns a reference to the 3-element
+    /// vector containing RGB white balance multipliers. These multipliers scale
+    /// the camera response to achieve proper white balance under the specified
+    /// illuminant conditions.
     ///
-    /// @return a reference to the 3-element white balance multiplier vector [R, G, B]
+    /// @return a reference to the 3-element white balance multiplier vector
+    /// [R, G, B]
     /// @pre white balance calculation must have been performed successfully
     const std::vector<double> &get_WB_multipliers() const;
 
-    /// Error message from the most recent method call that returned false.
-    std::string last_error_message;
-
-    int verbosity = 0;
+    /// Calculate an input transform matrix using curve fitting optimization.
+    /// This function computes the optimal IDT matrix by comparing camera RGB
+    /// responses with target XYZ values across all training patches.
+    /// The `camera`, `illuminant`, `observer` and `training_data` have to be
+    /// configured prior to this call.
+    ///
+    /// @return `true` if calculated successfully, `false` otherwise
+    /// @pre camera, illuminant, observer, and training_data must be properly
+    /// loaded
+    bool calculate_transform() override;
 
 private:
     std::vector<std::string>  _search_directories;
     std::vector<SpectralData> _all_illuminants;
 
-    std::vector<double>              _wb_multipliers;
-    std::vector<std::vector<double>> _idt_matrix;
+    std::vector<double> _wb_multipliers;
 };
 
 /// DNG metadata required to calculate an input transform.
@@ -217,45 +279,80 @@ struct Metadata
 };
 
 /// Solve an input transform using the metadata stored in DNG files.
-class MetadataSolver
+class MetadataSolver : public TransformSolver
 {
 public:
     /// Initialize the solver using DNG metadata.
     /// Creates a MetadataSolver instance with the provided camera metadata
     /// for calculating IDT and CAT matrices.
     ///
-    /// @param metadata DNG metadata containing camera calibration and exposure information
+    /// @param metadata DNG metadata containing camera calibration and exposure
+    /// information
     MetadataSolver( const core::Metadata &metadata );
 
-    /// Calculate the Input Device Transform (IDT) matrix for DNG color space conversion.
-    /// This function computes the final IDT matrix that transforms camera RGB values
-    /// to ACES RGB color space. It combines the Color Adaptation Transform (CAT) matrix
-    /// with the D65 ACES RGB to XYZ transformation matrix to create a complete
-    /// camera-to-ACES transformation pipeline.
+    // clang-format off
+
+    /// Calculate the Input Device Transform (IDT) matrix for DNG color space
+    /// conversion. This function computes the final IDT matrix that transforms
+    /// camera RGB values to ACES RGB color space. It combines the Color
+    /// Adaptation Transform (CAT) matrix with the D65 ACES RGB to XYZ
+    /// transformation matrix to create a complete camera-to-ACES transformation
+    /// pipeline.
     ///
     /// @return 3×3 Input Device Transform matrix for DNG to ACES conversion
     /// @pre _metadata must contain valid camera calibration data
     /// @pre calculate_CAT_matrix() must return a valid CAT matrix
+    [[deprecated(
+        "This method will be removed in v3. "
+        "Use `calculate_transform()`" )]]
     std::vector<std::vector<double>> calculate_IDT_matrix();
 
-    /// Calculate the Color Adaptation Transform (CAT) matrix for color space conversion.
-    /// This function computes the CAT matrix needed to transform colors from the camera's
-    /// white point to the target ACES RGB white point. It first obtains the camera's
-    /// XYZ transformation matrix and white point, then creates the target ACES RGB to XYZ
-    /// matrix, and finally calculates the color adaptation transform between the two
-    /// white points using the Bradford or CAT02 method.
+    /// Calculate the Color Adaptation Transform (CAT) matrix for color space
+    /// conversion. This function computes the CAT matrix needed to transform
+    /// colors from the camera's white point to the target ACES RGB white point.
+    /// It first obtains the camera's XYZ transformation matrix and white point,
+    /// then creates the target ACES RGB to XYZ matrix, and finally calculates
+    /// the color adaptation transform between the two white points using the
+    /// Bradford or CAT02 method.
     ///
-    /// The CAT matrix is essential for maintaining color appearance when converting
-    /// between different illuminant conditions, ensuring that colors look consistent
-    /// across different lighting environments. Strictly speaking, this matrix is not
-    /// required for image processing, as it is embedded in the IDT, see `calculate_IDT_matrix`.
+    /// The CAT matrix is essential for maintaining color appearance when
+    /// converting between different illuminant conditions, ensuring that colors
+    /// look consistent across different lighting environments. Strictly
+    /// speaking, this matrix is not required for image processing, as it is
+    /// embedded in the IDT, see `calculate_IDT_matrix`.
     ///
     /// @return 3×3 Color Adaptation Transform matrix
-    /// @pre _metadata must contain valid camera calibration and neutral RGB data
+    /// @pre _metadata must contain valid camera calibration and neutral RGB
+    /// data
+    [[deprecated(
+        "This method will be removed in v3. "
+        "Use `calculate_transform()`" )]]
     std::vector<std::vector<double>> calculate_CAT_matrix();
+
+    // clang-format on
+
+    /// Calculate the Input Device Transform (IDT) matrix for DNG color space
+    /// conversion. This function computes the final IDT matrix that transforms
+    /// camera RGB values to ACES RGB color space. It combines the Color
+    /// Adaptation Transform (CAT) matrix with the D65 ACES RGB to XYZ
+    /// transformation matrix to create a complete camera-to-ACES transformation
+    /// pipeline.
+    ///
+    /// @return `true` on success
+    /// @pre _metadata must contain valid camera calibration data
+    bool calculate_transform() override;
 
 private:
     core::Metadata _metadata;
+};
+
+/// A basic solver for the images in XYZ colour space with D65 white point.
+/// Simply calculates a transform matrix which performs XYZ to ACES conversion
+/// with chromatic adaptation from D65 to D60.
+class XYZD65Solver : public TransformSolver
+{
+public:
+    bool calculate_transform() override;
 };
 
 } // namespace core

--- a/include/rawtoaces/rawtoaces_core.h
+++ b/include/rawtoaces/rawtoaces_core.h
@@ -34,9 +34,9 @@ static const std::vector<std::vector<double> > CAT_D65_to_ACES = {
 // clang-format on
 
 /// Calculate spectral power distribution (SPD) of CIE standard daylight.
-/// illuminant. The function generates the spectral power distribution for a
-/// daylight illuminant based on the requested correlated color temperature
-/// using CIE standard formulas.
+/// The function generates the spectral power distribution for a daylight
+/// illuminant based on the requested correlated color temperature using CIE
+/// standard formulas.
 ///
 /// @param cct Correlated colour temperature of the requested illuminant either
 /// in Kelvin (in range of 4000-25000), or in short form from an illuminant

--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -5,6 +5,7 @@ nanobind_add_module( rawtoaces_bindings
     py_util.cpp py_util.h
     py_core.cpp py_core.h
     py_module.cpp
+    ../misc/pragma.h
 )
 
 target_link_libraries( rawtoaces_bindings

--- a/src/bindings/py_core.cpp
+++ b/src/bindings/py_core.cpp
@@ -6,6 +6,7 @@
 #include <nanobind/stl/vector.h>
 #include <rawtoaces/rawtoaces_core.h>
 #include <stdexcept>
+#include "../misc/pragma.h"
 
 using namespace rta::core;
 using namespace nanobind::literals;
@@ -74,14 +75,43 @@ void core_bindings( nanobind::module_ &m )
     bind_spectral_data( m );
     bind_metadata( m );
 
-    nanobind::class_<MetadataSolver> metadata_solver( m, "MetadataSolver" );
-    metadata_solver.def( nanobind::init<const Metadata &>() );
-    metadata_solver.def(
-        "calculate_CAT_matrix", &MetadataSolver::calculate_CAT_matrix );
-    metadata_solver.def(
-        "calculate_IDT_matrix", &MetadataSolver::calculate_IDT_matrix );
+    nanobind::class_<TransformSolver> transform_solver( m, "TransformSolver" );
+    transform_solver.def(
+        "calculate_transform", &TransformSolver::calculate_transform );
+    transform_solver.def_rw(
+        "transform_matrix", &TransformSolver::transform_matrix );
+    transform_solver.def_rw(
+        "last_error_message", &TransformSolver::last_error_message );
+    transform_solver.def_rw( "verbosity", &TransformSolver::verbosity );
 
-    nanobind::class_<SpectralSolver> spectral_solver( m, "SpectralSolver" );
+    nanobind::class_<MetadataSolver, TransformSolver> metadata_solver(
+        m, "MetadataSolver" );
+    metadata_solver.def( nanobind::init<const Metadata &>() );
+
+    DISABLE_DEPRECATED_WARNINGS
+    metadata_solver.def(
+        "calculate_CAT_matrix", []( MetadataSolver &metadata_solver ) {
+            PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "This method will be removed in v3. "
+                "Use `calculate_transform()`.",
+                1 );
+            return metadata_solver.calculate_CAT_matrix();
+        } );
+
+    metadata_solver.def(
+        "calculate_IDT_matrix", []( MetadataSolver &metadata_solver ) {
+            PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "This method will be removed in v3. "
+                "Use `calculate_transform()`.",
+                1 );
+            return metadata_solver.calculate_IDT_matrix();
+        } );
+    ENABLE_WARNINGS
+
+    nanobind::class_<SpectralSolver, TransformSolver> spectral_solver(
+        m, "SpectralSolver" );
     spectral_solver.def(
         nanobind::init<const std::vector<std::string> &>(),
         "search_directories"_a = std::vector<std::string>{} );
@@ -122,17 +152,33 @@ void core_bindings( nanobind::module_ &m )
         } );
     spectral_solver.def( "calculate_WB", &SpectralSolver::calculate_WB );
     spectral_solver.def(
-        "calculate_IDT_matrix", &SpectralSolver::calculate_IDT_matrix );
-    spectral_solver.def(
         "load_spectral_data", &SpectralSolver::load_spectral_data );
     spectral_solver.def(
         "get_WB_multipliers", &SpectralSolver::get_WB_multipliers );
-    spectral_solver.def( "get_IDT_matrix", &SpectralSolver::get_IDT_matrix );
     spectral_solver.def_rw( "camera", &SpectralSolver::camera );
     spectral_solver.def_rw( "illuminant", &SpectralSolver::illuminant );
     spectral_solver.def_rw( "observer", &SpectralSolver::observer );
     spectral_solver.def_rw( "training_data", &SpectralSolver::training_data );
-    spectral_solver.def_rw(
-        "last_error_message", &SpectralSolver::last_error_message );
-    spectral_solver.def_rw( "verbosity", &SpectralSolver::verbosity );
+
+    DISABLE_DEPRECATED_WARNINGS
+    spectral_solver.def(
+        "calculate_IDT_matrix", []( SpectralSolver &spectral_solver ) {
+            PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "This method will be removed in v3. "
+                "Use `calculate_transform()`.",
+                1 );
+            return spectral_solver.calculate_IDT_matrix();
+        } );
+
+    spectral_solver.def(
+        "get_IDT_matrix", []( SpectralSolver &spectral_solver ) {
+            PyErr_WarnEx(
+                PyExc_DeprecationWarning,
+                "This method will be removed in v3. "
+                "Use `transform_matrix`.",
+                1 );
+            return spectral_solver.get_IDT_matrix();
+        } );
+    ENABLE_WARNINGS
 }

--- a/src/bindings/py_util.cpp
+++ b/src/bindings/py_util.cpp
@@ -6,6 +6,7 @@
 #include <nanobind/stl/vector.h>
 #include <nanobind/ndarray.h>
 #include <rawtoaces/image_converter.h>
+#include "../misc/pragma.h"
 
 using namespace rta::util;
 
@@ -24,8 +25,29 @@ void util_bindings( nanobind::module_ &m )
     image_converter.def( "process_image", &ImageConverter::process_image );
     image_converter.def(
         "get_WB_multipliers", &ImageConverter::get_WB_multipliers );
-    image_converter.def( "get_IDT_matrix", &ImageConverter::get_IDT_matrix );
-    image_converter.def( "get_CAT_matrix", &ImageConverter::get_CAT_matrix );
+    image_converter.def(
+        "get_transform_matrix", &ImageConverter::get_transform_matrix );
+
+    DISABLE_DEPRECATED_WARNINGS
+    image_converter.def( "get_IDT_matrix", []( ImageConverter &converter ) {
+        PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "This method will be removed in v3. "
+            "Use `get_transform_matrix()`.",
+            1 );
+        return converter.get_IDT_matrix();
+    } );
+
+    image_converter.def( "get_CAT_matrix", []( ImageConverter &converter ) {
+        PyErr_WarnEx(
+            PyExc_DeprecationWarning,
+            "This method will be removed in v3. "
+            "Use `get_transform_matrix()`.",
+            1 );
+        return converter.get_CAT_matrix();
+    } );
+    ENABLE_WARNINGS
+
     image_converter.def(
         "configure",
         []( ImageConverter &converter, const std::string &input_filename ) {

--- a/src/misc/pragma.h
+++ b/src/misc/pragma.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the rawtoaces Project.
+
+#pragma once
+
+// clang-format off
+#ifdef WIN32
+#    define DISABLE_DEPRECATED_WARNINGS                                        \
+        _Pragma( "warning ( push )" )                                          \
+        _Pragma( "warning ( disable: 4996 )" )
+#    define ENABLE_WARNINGS                                                    \
+        _Pragma( "warning ( pop )" )
+#else
+#    define DISABLE_DEPRECATED_WARNINGS                                        \
+        _Pragma( "GCC diagnostic push" )                                       \
+        _Pragma( "GCC diagnostic ignored \"-Wdeprecated-declarations\"" )
+#    define ENABLE_WARNINGS                                                    \
+        _Pragma( "GCC diagnostic pop" )
+#endif
+// clang-format on

--- a/src/rawtoaces_core/rawtoaces_core.cpp
+++ b/src/rawtoaces_core/rawtoaces_core.cpp
@@ -1170,7 +1170,7 @@ bool camera_to_XYZ_weighted_matrix(
 
     if ( std::fabs( determinant( XYZ_to_camera_matrix ) ) < 1e-9 )
     {
-        error_message = "The found to XYZ to camera matrix is not inversible.";
+        error_message = "Found XYZ-to-camera matrix is not invertible.";
         out_matrix.resize( 0 );
         return false;
     }

--- a/src/rawtoaces_core/rawtoaces_core.cpp
+++ b/src/rawtoaces_core/rawtoaces_core.cpp
@@ -15,6 +15,14 @@ namespace rta
 namespace core
 {
 
+TransformSolver::TransformSolver()
+    : transform_matrix( 3, std::vector<double>( 3, 0 ) ), verbosity( 0 )
+{
+    transform_matrix[0][0] = 1.0;
+    transform_matrix[1][1] = 1.0;
+    transform_matrix[2][2] = 1.0;
+}
+
 /// Calculate the chromaticity values (x, y) based on correlated color temperature (CCT).
 /// The function converts a correlated color temperature to CIE 1931 chromaticity coordinates
 /// using empirical formulas for different temperature ranges.
@@ -174,21 +182,8 @@ bool generate_illuminant(
 
 SpectralSolver::SpectralSolver(
     const std::vector<std::string> &search_directories )
-    : _search_directories( search_directories )
-{
-    verbosity = 0;
-    _idt_matrix.resize( 3 );
-    _wb_multipliers.resize( 3 );
-    for ( int i = 0; i < 3; i++ )
-    {
-        _idt_matrix[i].resize( 3 );
-        _wb_multipliers[i] = 1.0;
-        for ( size_t j = 0; j < 3; j++ )
-        {
-            _idt_matrix[i][j] = neutral3[i][j];
-        }
-    }
-}
+    : _search_directories( search_directories ), _wb_multipliers( 3, 1.0 )
+{}
 
 /// Scale the illuminant (Light Source) to camera sensitivity data using the maximum RGB channel.
 /// This function normalizes the illuminant spectral data by scaling it based on the camera's
@@ -869,6 +864,11 @@ bool curveFit(
 
     if ( summary.num_successful_steps )
     {
+        out_IDT_matrix.resize( 3 );
+        out_IDT_matrix[0].resize( 3 );
+        out_IDT_matrix[1].resize( 3 );
+        out_IDT_matrix[2].resize( 3 );
+
         out_IDT_matrix[0][0] = beta_params[0];
         out_IDT_matrix[0][1] = beta_params[1];
         out_IDT_matrix[0][2] = 1.0 - beta_params[0] - beta_params[1];
@@ -896,7 +896,7 @@ bool curveFit(
     return false;
 }
 
-bool SpectralSolver::calculate_IDT_matrix()
+bool SpectralSolver::calculate_transform()
 {
     if ( camera.data.count( "main" ) == 0 ||
          camera.data.at( "main" ).size() != 3 )
@@ -940,7 +940,12 @@ bool SpectralSolver::calculate_IDT_matrix()
     auto RGB = calculate_RGB( camera, _wb_multipliers, TI );
     auto XYZ = calculate_XYZ( observer, illuminant, TI );
 
-    return curveFit( RGB, XYZ, beta_params_start, verbosity, _idt_matrix );
+    return curveFit( RGB, XYZ, beta_params_start, verbosity, transform_matrix );
+}
+
+bool SpectralSolver::calculate_IDT_matrix()
+{
+    return calculate_transform();
 }
 
 //	=====================================================================
@@ -954,7 +959,7 @@ bool SpectralSolver::calculate_IDT_matrix()
 
 const std::vector<std::vector<double>> &SpectralSolver::get_IDT_matrix() const
 {
-    return _idt_matrix;
+    return transform_matrix;
 }
 
 const std::vector<double> &SpectralSolver::get_WB_multipliers() const
@@ -1157,13 +1162,15 @@ bool camera_to_XYZ_weighted_matrix(
     const double                     &mired_end,
     const std::vector<double>        &matrix_start,
     const std::vector<double>        &matrix_end,
-    std::vector<std::vector<double>> &out_matrix )
+    std::vector<std::vector<double>> &out_matrix,
+    std::string                      &error_message )
 {
     auto XYZ_to_camera_matrix = XYZ_to_camera_weighted_matrix(
         mired_target, mired_start, mired_end, matrix_start, matrix_end );
 
     if ( std::fabs( determinant( XYZ_to_camera_matrix ) ) < 1e-9 )
     {
+        error_message = "The found to XYZ to camera matrix is not inversible.";
         out_matrix.resize( 0 );
         return false;
     }
@@ -1218,15 +1225,19 @@ stack_rows( const std::vector<double> &matrix, size_t columns )
 bool find_camera_to_XYZ_matrix(
     const Metadata                   &metadata,
     const std::vector<double>        &neutral_RGB,
-    std::vector<std::vector<double>> &out_matrix )
+    std::vector<std::vector<double>> &out_matrix,
+    std::string                      &error_message,
+    int                               verbosity )
 {
     if ( metadata.calibration[0].illuminant == 0 )
     {
-        std::cerr << "No calibration illuminants were found." << std::endl;
+        if ( verbosity > 0 )
+            std::cerr << "No calibration illuminants were found." << std::endl;
     }
     else if ( neutral_RGB.size() == 0 )
     {
-        std::cerr << "No neutral RGB values were found." << std::endl;
+        if ( verbosity > 0 )
+            std::cerr << "No neutral RGB values were found." << std::endl;
     }
     else
     {
@@ -1258,6 +1269,7 @@ bool find_camera_to_XYZ_matrix(
         double current_mired = low_mired;
         while ( current_mired < high_mired )
         {
+            std::string                      local_error_message;
             std::vector<std::vector<double>> camera_to_XYZ_matrix;
             if ( !camera_to_XYZ_weighted_matrix(
                      current_mired,
@@ -1265,7 +1277,8 @@ bool find_camera_to_XYZ_matrix(
                      mir2,
                      matrix_start,
                      matrix_end,
-                     camera_to_XYZ_matrix ) )
+                     camera_to_XYZ_matrix,
+                     local_error_message ) )
             {
                 current_mired += mired_step;
                 continue;
@@ -1305,13 +1318,21 @@ bool find_camera_to_XYZ_matrix(
 
         if ( estimated_mired != 0.0 )
         {
+            if ( verbosity > 1 )
+            {
+                std::cerr << "Found illuminant: "
+                          << int( mired_to_kelvin( estimated_mired ) ) << "k."
+                          << std::endl;
+            }
+
             if ( camera_to_XYZ_weighted_matrix(
                      estimated_mired,
                      mir1,
                      mir2,
                      matrix_start,
                      matrix_end,
-                     out_matrix ) )
+                     out_matrix,
+                     error_message ) )
             {
                 return true;
             }
@@ -1323,7 +1344,7 @@ bool find_camera_to_XYZ_matrix(
         stack_rows( metadata.calibration[0].XYZ_to_RGB_matrix, 3 );
     if ( std::fabs( determinant( XYZ_to_camera_matrix ) ) < 1e-9 )
     {
-        std::cerr << "Failed to find a suitable illuminant." << std::endl;
+        error_message = "Failed to find a suitable illuminant.";
         out_matrix.resize( 0 );
         return false;
     }
@@ -1446,11 +1467,17 @@ std::vector<double> matrix_RGB_to_XYZ( const double chromaticities[][2] )
 bool get_camera_XYZ_matrix_and_white_point(
     const Metadata                   &metadata,
     std::vector<std::vector<double>> &out_camera_to_XYZ_matrix,
-    std::vector<double>              &out_camera_XYZ_white_point )
+    std::vector<double>              &out_camera_XYZ_white_point,
+    std::string                      &error_message,
+    int                               verbosity )
 {
 
     if ( !find_camera_to_XYZ_matrix(
-             metadata, metadata.neutral_RGB, out_camera_to_XYZ_matrix ) )
+             metadata,
+             metadata.neutral_RGB,
+             out_camera_to_XYZ_matrix,
+             error_message,
+             verbosity ) )
     {
         return false;
     }
@@ -1476,32 +1503,60 @@ bool get_camera_XYZ_matrix_and_white_point(
     return true;
 }
 
-std::vector<std::vector<double>> MetadataSolver::calculate_CAT_matrix()
+static bool calculate_DNG_CAT_matrix(
+    Metadata                         &metadata,
+    std::vector<std::vector<double>> &out_matrix,
+    std::string                      &error_message,
+    int                               verbosity )
 {
-    std::vector<std::vector<double>> CAT_matrix;
-
     std::vector<double>              deviceWhiteV( 3, 1.0 );
     std::vector<std::vector<double>> camera_to_XYZ_matrix;
     std::vector<double>              camera_XYZ_white_point;
 
     if ( get_camera_XYZ_matrix_and_white_point(
-             _metadata, camera_to_XYZ_matrix, camera_XYZ_white_point ) )
+             metadata,
+             camera_to_XYZ_matrix,
+             camera_XYZ_white_point,
+             error_message,
+             verbosity ) )
     {
         std::vector<double> output_RGB_to_XYZ_matrix =
             matrix_RGB_to_XYZ( chromaticitiesACES );
         std::vector<double> output_XYZ_white_point =
             mulVector( output_RGB_to_XYZ_matrix, deviceWhiteV );
-        CAT_matrix =
+        out_matrix =
             calculate_CAT( camera_XYZ_white_point, output_XYZ_white_point );
+        return true;
     }
-
-    return CAT_matrix;
+    else
+    {
+        out_matrix.resize( 0 );
+        return false;
+    }
 }
 
-std::vector<std::vector<double>> MetadataSolver::calculate_IDT_matrix()
+std::vector<std::vector<double>> MetadataSolver::calculate_CAT_matrix()
+{
+    std::vector<std::vector<double>> result;
+    calculate_DNG_CAT_matrix(
+        _metadata, result, last_error_message, verbosity );
+    return result;
+}
+
+static bool calculate_DNG_IDT_matrix(
+    Metadata                         &metadata,
+    std::vector<std::vector<double>> &out_matrix,
+    std::string                      &error_message,
+    int                               verbosity )
 {
     // 1. Obtains the CAT matrix for white point adaptation
-    std::vector<std::vector<double>> CAT_matrix = calculate_CAT_matrix();
+    std::vector<std::vector<double>> CAT_matrix;
+    if ( !calculate_DNG_CAT_matrix(
+             metadata, CAT_matrix, error_message, verbosity ) )
+    {
+        out_matrix.resize( 0 );
+        return false;
+    }
 
     // 2. Converts the CAT matrix to a flattened format for matrix multiplication
     std::vector<double> XYZ_D65_acesrgb( 9 ), CAT( 9 );
@@ -1516,16 +1571,54 @@ std::vector<std::vector<double>> MetadataSolver::calculate_IDT_matrix()
     std::vector<double> matrix = mulVector( XYZ_D65_acesrgb, CAT, 3 );
 
     // 4. Reshapes the result into a 3×3 transformation matrix
-    std::vector<std::vector<double>> DNG_IDT_matrix(
-        3, std::vector<double>( 3 ) );
+    out_matrix.resize( 3 );
     for ( size_t i = 0; i < 3; i++ )
+    {
+        out_matrix[i].resize( 3 );
         for ( size_t j = 0; j < 3; j++ )
-            DNG_IDT_matrix[i][j] = matrix[i * 3 + j];
+            out_matrix[i][j] = matrix[i * 3 + j];
+    }
 
     // 5. Validates the matrix properties (non-zero determinant)
-    assert( std::fabs( sumVectorM( DNG_IDT_matrix ) - 0.0 ) > 1e-09 );
+    assert( std::fabs( sumVectorM( out_matrix ) - 0.0 ) > 1e-09 );
+    return true;
+}
 
-    return DNG_IDT_matrix;
+std::vector<std::vector<double>> MetadataSolver::calculate_IDT_matrix()
+{
+    std::vector<std::vector<double>> result;
+    calculate_DNG_IDT_matrix(
+        _metadata, result, last_error_message, verbosity );
+    return result;
+}
+
+bool MetadataSolver::calculate_transform()
+{
+    return calculate_DNG_IDT_matrix(
+        _metadata, transform_matrix, last_error_message, verbosity );
+}
+
+bool XYZD65Solver::calculate_transform()
+{
+    // clang-format off
+    /// Colour adaptation from D65 to the ACES white point
+    static const std::vector<std::vector<double>> D65_to_ACES = {
+        {  1.0097583639200136,   0.0050178093846550, -0.0150583890923881 },
+        {  0.0036602813378778,   1.0030138169214682, -0.0059802329456400 },
+        { -0.00029980928869025, -0.0010516909063250,  0.9282027962747658 }
+    };
+
+    /// Colour space transform from XYZ D60 to ACES
+    static const std::vector<std::vector<double>> XYZ_D60_to_ACES = {
+        {  1.0498110175, 0.0000000000, -0.0000974845 },
+        { -0.4959030231, 1.3733130458,  0.0982400361 },
+        {  0.0000000000, 0.0000000000,  0.9912520182 }
+    };
+    // clang-format on
+
+    transform_matrix =
+        mulVector( XYZ_D60_to_ACES, transposeVec( D65_to_ACES ) );
+    return true;
 }
 
 /// Cost function operator for Ceres optimization of IDT matrix parameters.

--- a/src/rawtoaces_core/rawtoaces_core_priv.h
+++ b/src/rawtoaces_core/rawtoaces_core_priv.h
@@ -68,11 +68,15 @@ stack_rows( const std::vector<double> &matrix, size_t columns );
 bool find_camera_to_XYZ_matrix(
     const Metadata                   &metadata,
     const std::vector<double>        &neutralRGB,
-    std::vector<std::vector<double>> &out_matrix );
+    std::vector<std::vector<double>> &out_matrix,
+    std::string                      &error_message,
+    int                               verbosity );
 
 bool get_camera_XYZ_matrix_and_white_point(
     const Metadata                   &metadata,
     std::vector<std::vector<double>> &out_camera_to_XYZ_matrix,
-    std::vector<double>              &out_camera_XYZ_white_point );
+    std::vector<double>              &out_camera_XYZ_white_point,
+    std::string                      &error_message,
+    int                               verbosity );
 } // namespace core
 } // namespace rta

--- a/src/rawtoaces_util/colour_transforms.cpp
+++ b/src/rawtoaces_util/colour_transforms.cpp
@@ -313,16 +313,15 @@ bool solve_matrix_from_illuminant(
         return false;
     }
 
-    if ( !solver.calculate_IDT_matrix() )
+    if ( !solver.calculate_transform() )
     {
         error_message = solver.last_error_message;
         return false;
     }
 
-    const auto &matrix = solver.get_IDT_matrix();
     for ( size_t row = 0; row < 3; row++ )
         for ( size_t col = 0; col < 3; col++ )
-            cache_data[row][col] = matrix[row][col];
+            cache_data[row][col] = solver.transform_matrix[row][col];
 
     return true;
 }
@@ -391,22 +390,30 @@ bool fetch_matrix_from_illuminant(
     return true;
 }
 
-void solve_matrix_from_metadata(
-    const core::Metadata &metadata, cache::MatrixData &cache_data )
+bool solve_matrix_from_metadata(
+    const core::Metadata &metadata,
+    cache::MatrixData    &cache_data,
+    std::string          &error_message )
 {
     core::MetadataSolver solver( metadata );
-    auto                 matrix = solver.calculate_IDT_matrix();
+    if ( !solver.calculate_transform() )
+    {
+        error_message = solver.last_error_message;
+        return false;
+    }
 
     for ( size_t row = 0; row < 3; row++ )
         for ( size_t col = 0; col < 3; col++ )
-            cache_data[row][col] = matrix[row][col];
+            cache_data[row][col] = solver.transform_matrix[row][col];
+    return true;
 }
 
-void fetch_matrix_from_metadata(
+bool fetch_matrix_from_metadata(
     const core::Metadata             &metadata,
     int                               verbosity,
     bool                              disable_cache,
-    std::vector<std::vector<double>> &out_matrix )
+    std::vector<std::vector<double>> &out_matrix,
+    std::string                      &error_message )
 {
     cache::MetadataDescriptor descriptor = metadata;
 
@@ -417,9 +424,18 @@ void fetch_matrix_from_metadata(
 
     const auto &entry = matrix_from_dng_metadata_cache.fetch(
         descriptor, [&]( cache::MatrixData &cache_data ) {
-            solve_matrix_from_metadata( metadata, cache_data );
-            return true;
+            return solve_matrix_from_metadata(
+                metadata, cache_data, error_message );
         } );
+
+    bool success = entry.first;
+    if ( !success )
+    {
+        error_message =
+            "Failed to calculate transform matrix from DNG metadata. " +
+            error_message;
+        return false;
+    }
 
     const auto &matrix = entry.second;
     out_matrix.resize( 3 );
@@ -443,6 +459,7 @@ void fetch_matrix_from_metadata(
             std::cerr << std::endl;
         }
     }
+    return true;
 }
 
 } // namespace util

--- a/src/rawtoaces_util/colour_transforms.h
+++ b/src/rawtoaces_util/colour_transforms.h
@@ -43,11 +43,12 @@ bool fetch_matrix_from_illuminant(
     std::vector<std::vector<double>> &out_matrix,
     std::string                      &error_message );
 
-void fetch_matrix_from_metadata(
+bool fetch_matrix_from_metadata(
     const core::Metadata             &metadata,
     int                               verbosity,
     bool                              disable_cache,
-    std::vector<std::vector<double>> &out_matrix );
+    std::vector<std::vector<double>> &out_matrix,
+    std::string                      &error_message );
 
 } // namespace util
 } // namespace rta

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -2155,7 +2155,6 @@ bool ImageConverter::configure(
             _cat_matrix.resize( 0 );
             break;
 
-            
         default:
             status = Status::ConfigurationError;
             last_error_message =

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -365,22 +365,20 @@ CameraIdentifier get_camera_identifier(
 /// This method initializes a spectral solver to find the appropriate camera data,
 /// loads training and observer spectral data, determines the illuminant (either from
 /// settings or by analyzing white balance multipliers), calculates white balance
-/// coefficients, and computes the IDT matrix. The CAT (Chromatic Adaptation Transform) matrix is not used in spectral
-/// mode as chromatic adaptation is embedded within the IDT (Input Device Transform) matrix.
+/// coefficients, and computes the IDT matrix.
 ///
 /// @param image_spec OpenImageIO image specification containing metadata
 /// @param settings ImageConverter settings including illuminant and verbosity
 /// @param WB_multipliers Output white balance multipliers (3-element vector)
-/// @param IDT_matrix Output Input Device Transform matrix (3x3 matrix)
-/// @param CAT_matrix Output Chromatic Adaptation Transform matrix (cleared in spectral mode)
+/// @param out_transform_matrix Output Input Device Transform matrix
+/// (3x3 matrix)
 /// @return true if transformation matrices were successfully prepared, false otherwise
 /// @param error_message Output parameter to capture error message if function returns false
 bool prepare_transform_spectral(
     const OIIO::ImageSpec            &image_spec,
     const ImageConverter::Settings   &settings,
     std::vector<double>              &WB_multipliers,
-    std::vector<std::vector<double>> &IDT_matrix,
-    std::vector<std::vector<double>> &CAT_matrix,
+    std::vector<std::vector<double>> &out_transform_matrix,
     std::string                      &error_message )
 {
     // Initialize and validate camera identification
@@ -481,17 +479,13 @@ bool prepare_transform_spectral(
         solver,
         settings.verbosity,
         settings.disable_cache,
-        IDT_matrix,
+        out_transform_matrix,
         error_message );
 
     if ( !success )
     {
         return false;
     }
-
-    // Step 7: Clear CAT matrix (not used in spectral mode)
-    // CAT is embedded in IDT in spectral mode
-    CAT_matrix.resize( 0 );
 
     return true;
 }
@@ -2051,17 +2045,6 @@ bool ImageConverter::configure(
         case Settings::MatrixMethod::Custom:
             options["raw:ColorSpace"]        = "raw";
             options["raw:use_camera_matrix"] = 0;
-
-            _idt_matrix.resize( 3 );
-            for ( int i = 0; i < 3; i++ )
-            {
-                _idt_matrix[i].resize( 3 );
-                for ( int j = 0; j < 3; j++ )
-                {
-                    _idt_matrix[i][j] =
-                        static_cast<double>( settings.custom_matrix[i][j] );
-                }
-            }
             break;
         default:
             status = Status::ConfigurationError;
@@ -2081,8 +2064,7 @@ bool ImageConverter::configure(
                  image_spec,
                  settings,
                  _wb_multipliers,
-                 _idt_matrix,
-                 _cat_matrix,
+                 _transform_matrix,
                  error_msg ) )
         {
             status             = Status::ConfigurationError;
@@ -2092,8 +2074,6 @@ bool ImageConverter::configure(
                                      : error_msg;
             return false;
         }
-
-        _transform_matrix = _idt_matrix;
 
         if ( is_spectral_white_balance )
         {
@@ -2113,41 +2093,74 @@ bool ImageConverter::configure(
         }
     }
 
-    if ( matrix_method == Settings::MatrixMethod::Metadata )
+    switch ( matrix_method )
     {
-        if ( is_DNG )
-        {
-            options["raw:use_camera_matrix"] = 1;
-            options["raw:use_camera_wb"]     = 1;
+        case Settings::MatrixMethod::Spectral:
+            // prepare_transform_spectral() has already been called above.
+            // Fill in the legacy matrices.
+            _idt_matrix = _transform_matrix;
+            _cat_matrix.resize( 0 );
+            break;
 
-            std::string error_msg;
-            if ( !prepare_transform_DNG(
-                     image_spec,
-                     settings,
-                     _idt_matrix,
-                     _cat_matrix,
-                     error_msg ) )
+        case Settings::MatrixMethod::Metadata:
+            if ( is_DNG )
             {
-                status = Status::ConfigurationError;
-                last_error_message =
-                    error_msg.empty()
-                        ? "Colour space transform has not been configured properly (metadata mode)"
-                        : error_msg;
-                return false;
-            }
+                options["raw:use_camera_matrix"] = 1;
+                options["raw:use_camera_wb"]     = 1;
 
-            _transform_matrix = _idt_matrix;
-        }
-        else
-        {
+                std::string error_msg;
+                if ( !prepare_transform_DNG(
+                         image_spec,
+                         settings,
+                         _idt_matrix,
+                         _cat_matrix,
+                         error_msg ) )
+                {
+                    status = Status::ConfigurationError;
+                    last_error_message =
+                        error_msg.empty()
+                            ? "Colour space transform has not been configured "
+                              "properly (metadata mode)"
+                            : error_msg;
+                    return false;
+                }
+
+                _transform_matrix = _idt_matrix;
+            }
+            else
+            {
+                prepare_transform_nonDNG( _transform_matrix, _cat_matrix );
+                _idt_matrix.resize( 0 );
+            }
+            break;
+
+        case Settings::MatrixMethod::Adobe:
             prepare_transform_nonDNG( _transform_matrix, _cat_matrix );
             _idt_matrix.resize( 0 );
-        }
-    }
-    else if ( matrix_method == Settings::MatrixMethod::Adobe )
-    {
-        prepare_transform_nonDNG( _transform_matrix, _cat_matrix );
-        _idt_matrix.resize( 0 );
+            break;
+
+        case Settings::MatrixMethod::Custom:
+            _transform_matrix.resize( 3 );
+            for ( size_t i = 0; i < 3; i++ )
+            {
+                _transform_matrix[i].resize( 3 );
+                for ( size_t j = 0; j < 3; j++ )
+                {
+                    _transform_matrix[i][j] =
+                        static_cast<double>( settings.custom_matrix[i][j] );
+                }
+            }
+
+            _idt_matrix = _transform_matrix;
+            _cat_matrix.resize( 0 );
+            break;
+
+            
+        default:
+            status = Status::ConfigurationError;
+            last_error_message =
+                "Matrix method has not been configured properly";
+            return false;
     }
 
     if ( settings.verbosity > 1 )

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -516,9 +516,6 @@ bool prepare_transform_DNG(
     std::vector<std::vector<double>> &CAT_matrix,
     std::string                      &error_message )
 {
-    (void)
-        error_message; // Currently unused, but kept for consistency with prepare_transform_spectral interface
-
     // Step 1: Extract basic DNG metadata
     core::Metadata metadata;
 
@@ -586,22 +583,26 @@ bool prepare_transform_DNG(
         }
     }
 
-    // Step 4: Calculate IDT matrix using metadata solver
-    fetch_matrix_from_metadata(
-        metadata, settings.verbosity, settings.disable_cache, IDT_matrix );
-
-    // Step 5: Clear CAT matrix (not used for DNG)
+    // Step 4: Clear CAT matrix (not used for DNG)
     // Do not apply CAT for DNG
     CAT_matrix.resize( 0 );
-    return true;
+
+    // Step 5: Calculate IDT matrix using metadata solver
+    return fetch_matrix_from_metadata(
+        metadata,
+        settings.verbosity,
+        settings.disable_cache,
+        IDT_matrix,
+        error_message );
 }
 
 void prepare_transform_nonDNG(
-    std::vector<std::vector<double>> &IDT_matrix,
+    std::vector<std::vector<double>> &transform_matrix,
     std::vector<std::vector<double>> &CAT_matrix )
 {
-    // Do not apply IDT for non-DNG
-    IDT_matrix.resize( 0 );
+    rta::core::XYZD65Solver solver;
+    solver.calculate_transform();
+    transform_matrix = solver.transform_matrix;
 
     // clang-format off
     // Colour adaptation from D65 to the ACES white point
@@ -2084,13 +2085,15 @@ bool ImageConverter::configure(
                  _cat_matrix,
                  error_msg ) )
         {
-            status = Status::ConfigurationError;
-            last_error_message =
-                error_msg.empty()
-                    ? "Colour space transform has not been configured properly (spectral mode)"
-                    : error_msg;
+            status             = Status::ConfigurationError;
+            last_error_message = error_msg.empty()
+                                     ? "Colour space transform has not been "
+                                       "configured properly (spectral mode)"
+                                     : error_msg;
             return false;
         }
+
+        _transform_matrix = _idt_matrix;
 
         if ( is_spectral_white_balance )
         {
@@ -2132,15 +2135,19 @@ bool ImageConverter::configure(
                         : error_msg;
                 return false;
             }
+
+            _transform_matrix = _idt_matrix;
         }
         else
         {
-            prepare_transform_nonDNG( _idt_matrix, _cat_matrix );
+            prepare_transform_nonDNG( _transform_matrix, _cat_matrix );
+            _idt_matrix.resize( 0 );
         }
     }
     else if ( matrix_method == Settings::MatrixMethod::Adobe )
     {
-        prepare_transform_nonDNG( _idt_matrix, _cat_matrix );
+        prepare_transform_nonDNG( _transform_matrix, _cat_matrix );
+        _idt_matrix.resize( 0 );
     }
 
     if ( settings.verbosity > 1 )
@@ -2378,41 +2385,13 @@ bool ImageConverter::apply_matrix(
     if ( !roi.defined() )
         roi = dst.roi();
 
-    if ( _idt_matrix.size() )
+    if ( _transform_matrix.size() )
     {
-        success = rta::util::apply_matrix( _idt_matrix, dst, src, roi );
+        success = rta::util::apply_matrix( _transform_matrix, dst, src, roi );
         if ( !success )
         {
             status             = Status::MatrixApplicationError;
-            last_error_message = "Failed to apply IDT matrix transformation";
-            return false;
-        }
-    }
-
-    if ( _cat_matrix.size() )
-    {
-        success = rta::util::apply_matrix( _cat_matrix, dst, dst, roi );
-        if ( !success )
-        {
-            status             = Status::MatrixApplicationError;
-            last_error_message = "Failed to apply CAT matrix transformation";
-            return false;
-        }
-
-        // clang-format off
-        static const std::vector<std::vector<double>> XYZ_to_ACES = {
-            {  1.0498110175, 0.0000000000, -0.0000974845 },
-            { -0.4959030231, 1.3733130458,  0.0982400361 },
-            {  0.0000000000, 0.0000000000,  0.9912520182 }
-        };
-        // clang-format on
-
-        success = rta::util::apply_matrix( XYZ_to_ACES, dst, dst, roi );
-        if ( !success )
-        {
-            status = Status::MatrixApplicationError;
-            last_error_message =
-                "Failed to apply XYZ to ACES matrix transformation";
+            last_error_message = "Failed to apply the colour transform matrix.";
             return false;
         }
     }
@@ -2776,5 +2755,10 @@ const std::vector<std::vector<double>> &ImageConverter::get_CAT_matrix() const
     return _cat_matrix;
 }
 
+const std::vector<std::vector<double>> &
+ImageConverter::get_transform_matrix() const
+{
+    return _transform_matrix;
+}
 } //namespace util
 } //namespace rta

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -2127,12 +2127,12 @@ bool ImageConverter::configure(
             if ( is_DNG )
             {
                 options["raw:use_camera_matrix"] = 1;
-                options["raw:use_camera_wb"]     = 1;
 
                 std::string error_msg;
                 if ( !prepare_transform_DNG(
                          image_spec,
                          settings,
+                         _wb_multipliers,
                          _idt_matrix,
                          _cat_matrix,
                          error_msg ) )

--- a/src/rawtoaces_util/rawtoaces_util_priv.h
+++ b/src/rawtoaces_util/rawtoaces_util_priv.h
@@ -37,8 +37,7 @@ bool prepare_transform_spectral(
     const OIIO::ImageSpec            &image_spec,
     const ImageConverter::Settings   &settings,
     std::vector<double>              &WB_multipliers,
-    std::vector<std::vector<double>> &IDT_matrix,
-    std::vector<std::vector<double>> &CAT_matrix,
+    std::vector<std::vector<double>> &out_transform_matrix,
     std::string                      &error_message );
 
 } // namespace util

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable (
 	Test_IDT
 	testIDT.cpp
 	test_utils.cpp
+    	../src/misc/pragma.h
 )
 
 target_link_libraries(
@@ -113,6 +114,7 @@ add_executable (
 	Test_DNGIdt
 	testDNGIdt.cpp
 	test_utils.cpp
+    	../src/misc/pragma.h
 )
 
 target_link_libraries(

--- a/tests/config_tests/util/test_installed_util.cpp
+++ b/tests/config_tests/util/test_installed_util.cpp
@@ -72,7 +72,7 @@ void test_AcesRender()
         bool result = converter.configure( pathToRaw.string(), hints );
         OIIO_CHECK_EQUAL( result, true );
 
-        auto idt = converter.get_IDT_matrix();
+        const auto &idt = converter.get_transform_matrix();
 
         double matrix[3][3] = { { 1.0536466144, 0.0039044182, 0.0049084502 },
                                 { -0.4899562165, 1.3614787986, 0.1020844728 },

--- a/tests/python/test_core_bindings.py
+++ b/tests/python/test_core_bindings.py
@@ -164,6 +164,26 @@ class TestMetadataSolverBindings:
         assert abs(idt[2][2] - 1.0139159537) < 1e-5
 
 
+    def test_metadata_solver_calculate_transform(self):
+        metadata = _init_reference_metadata()
+        solver = rawtoaces.MetadataSolver(metadata)
+        success = solver.calculate_transform()
+        idt = solver.transform_matrix
+
+        assert success
+        assert len(idt) == 3
+        assert len(idt[0]) == 3
+        assert abs(idt[0][0] - 1.0536466144) < 1e-5
+        assert abs(idt[0][1] - 0.0039044182) < 1e-5
+        assert abs(idt[0][2] - 0.0049084502) < 1e-5
+        assert abs(idt[1][0] - -0.4899562165) < 1e-5
+        assert abs(idt[1][1] - 1.3614787986) < 1e-5
+        assert abs(idt[1][2] - 0.1020844728) < 1e-5
+        assert abs(idt[2][0] - -0.0024498461) < 1e-5
+        assert abs(idt[2][1] - 0.0060497128) < 1e-5
+        assert abs(idt[2][2] - 1.0139159537) < 1e-5
+
+
 class TestSpectralSolverBindings:
     def test_spectral_solver_default_constructor(self):
         solver = rawtoaces.SpectralSolver()
@@ -304,6 +324,7 @@ class TestSpectralSolverBindings:
         )
         assert solver.calculate_WB() is True
         assert solver.calculate_IDT_matrix() is True
+        assert solver.calculate_transform() is True
 
         wb = solver.get_WB_multipliers()
         idt = solver.get_IDT_matrix()

--- a/tests/python/test_image_converter.py
+++ b/tests/python/test_image_converter.py
@@ -71,7 +71,10 @@ class TestImageConverter:
                 
         assert hasattr(converter, "get_CAT_matrix")
         assert callable(converter.get_CAT_matrix)
-                        
+
+        assert hasattr(converter, "get_transform_matrix")
+        assert callable(converter.get_transform_matrix)
+
         assert hasattr(converter, "get_supported_illuminants")
         assert callable(converter.get_supported_illuminants)
 
@@ -129,6 +132,7 @@ class TestImageConverter:
 
         idt = converter.get_IDT_matrix()
         cat = converter.get_CAT_matrix()
+        transform_matrix = converter.get_transform_matrix()
 
         # Older versions of OIIO fail to fetch the DNG metadata, so rawtoaces
         # picks the non-DNG path. Ideally we should restrict the supported
@@ -148,6 +152,19 @@ class TestImageConverter:
             assert abs(idt[2][0] - -0.0024498461419844484) < 0.0001
             assert abs(idt[2][1] - 0.006049712791275535) < 0.0001
             assert abs(idt[2][2] - 1.013915953697747) < 0.0001
+
+            assert len(transform_matrix[0]) == 3
+            assert abs(transform_matrix[0][0] - 1.0536466144250152) < 0.0001
+            assert abs(transform_matrix[0][1] - 0.00390441818863832) < 0.0001
+            assert abs(transform_matrix[0][2] - 0.004908450238340354) < 0.0001
+            assert len(transform_matrix[1]) == 3
+            assert abs(transform_matrix[1][0] - -0.48995621645381615) < 0.0001
+            assert abs(transform_matrix[1][1] - 1.3614787985962031) < 0.0001
+            assert abs(transform_matrix[1][2] - 0.10208447284831194) < 0.0001
+            assert len(transform_matrix[2]) == 3
+            assert abs(transform_matrix[2][0] - -0.0024498461419844484) < 0.0001
+            assert abs(transform_matrix[2][1] - 0.006049712791275535) < 0.0001
+            assert abs(transform_matrix[2][2] - 1.013915953697747) < 0.0001
         elif len(idt) == 0 and len(cat) == 3:
             assert len(cat[0]) == 3
             assert abs(cat[0][0] - 1.0097583639200136) < 0.0001
@@ -161,6 +178,19 @@ class TestImageConverter:
             assert abs(cat[2][0] - -0.00029980928869024906) < 0.0001
             assert abs(cat[2][1] - -0.0010516909063249997) < 0.0001
             assert abs(cat[2][2] - 0.9282027962747658) < 0.0001
+            
+            assert len(transform_matrix[0]) == 3
+            assert abs(transform_matrix[0][0] - 1.0600554846827632) < 0.0001
+            assert abs(transform_matrix[0][1] - 0.005267854099287872) < 0.0001
+            assert abs(transform_matrix[0][2] - -0.0158989481604843) < 0.0001
+            assert len(transform_matrix[1]) == 3
+            assert abs(transform_matrix[1][0] - -0.4957449664311829) < 0.0001
+            assert abs(transform_matrix[1][1] - 1.3748602949001116) < 0.0001
+            assert abs(transform_matrix[1][2] - 0.09044144496691488) < 0.0001
+            assert len(transform_matrix[2]) == 3
+            assert abs(transform_matrix[2][0] - -0.00029718656248931675) < 0.0001
+            assert abs(transform_matrix[2][1] - -0.0010424907334172433) < 0.0001
+            assert abs(transform_matrix[2][2] - 0.920082895106245) < 0.0001
         else:
             pytest.fail("Either IDT or CAT matrix must not be empty")
 
@@ -199,6 +229,16 @@ class TestImageConverter:
         try:
             cat = converter.get_CAT_matrix()
             assert len(cat) == 0
+        except Exception as e:
+            pytest.fail(f"Unexpected exception: {e}")
+
+    def test_converter_get_transform_matrix(self):
+        """Test uninitialised ImageConverter returns empty transform matrix"""
+        import os
+        converter = rawtoaces.ImageConverter()
+        try:
+            transform_matrix = converter.get_transform_matrix()
+            assert len(transform_matrix) == 0
         except Exception as e:
             pytest.fail(f"Unexpected exception: {e}")
 

--- a/tests/testColourTransforms.cpp
+++ b/tests/testColourTransforms.cpp
@@ -293,9 +293,9 @@ void test_fetch_matrix_from_illuminant_cache_hit()
         "cmf/cmf_1931.json", solver_expected.observer ) );
     OIIO_CHECK_ASSERT( solver_expected.find_illuminant( "D65" ) );
     OIIO_CHECK_ASSERT( solver_expected.calculate_WB() );
-    OIIO_CHECK_ASSERT( solver_expected.calculate_IDT_matrix() );
+    OIIO_CHECK_ASSERT( solver_expected.calculate_transform() );
 
-    const auto &expected = solver_expected.get_IDT_matrix();
+    const auto &expected = solver_expected.transform_matrix;
     OIIO_CHECK_EQUAL( matrix.size(), 3 );
     OIIO_CHECK_EQUAL( matrix[0].size(), 3 );
     for ( size_t row = 0; row < 3; row++ )
@@ -326,11 +326,21 @@ void test_fetch_matrix_from_metadata_cache_hit_and_values()
     init_metadata( metadata );
 
     std::vector<std::vector<double>> matrix;
+    bool                             success1;
+    bool                             success2;
+    std::string                      error_message1;
+    std::string                      error_message2;
     std::string                      output = capture_stderr( [&]() {
-        rta::util::fetch_matrix_from_metadata( metadata, 1, false, matrix );
-        rta::util::fetch_matrix_from_metadata( metadata, 1, false, matrix );
+        success1 = rta::util::fetch_matrix_from_metadata(
+            metadata, 1, false, matrix, error_message1 );
+        success2 = rta::util::fetch_matrix_from_metadata(
+            metadata, 1, false, matrix, error_message2 );
     } );
 
+    OIIO_CHECK_ASSERT( success1 );
+    OIIO_CHECK_ASSERT( success2 );
+    OIIO_CHECK_ASSERT( error_message1.empty() );
+    OIIO_CHECK_ASSERT( error_message2.empty() );
     OIIO_CHECK_EQUAL( matrix.size(), 3 );
     OIIO_CHECK_EQUAL( matrix[0].size(), 3 );
     ASSERT_CONTAINS(
@@ -341,7 +351,10 @@ void test_fetch_matrix_from_metadata_cache_hit_and_values()
     ASSERT_CONTAINS( output, "Input Device Transform (IDT) matrix:" );
 
     rta::core::MetadataSolver solver( metadata );
-    auto                      expected = solver.calculate_IDT_matrix();
+    bool                      success = solver.calculate_transform();
+    OIIO_CHECK_ASSERT( success );
+
+    auto &expected = solver.transform_matrix;
     for ( size_t row = 0; row < 3; row++ )
     {
         for ( size_t col = 0; col < 3; col++ )
@@ -350,6 +363,33 @@ void test_fetch_matrix_from_metadata_cache_hit_and_values()
                 matrix[row][col], expected[row][col], 1e-7 );
         }
     }
+}
+
+void test_fetch_matrix_from_metadata_failure_clears_output()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    std::vector<double> non_invertible_mat = { 1, 0, 0, 1, 0, 0, 1, 0, 0 };
+
+    rta::core::Metadata metadata;
+    init_metadata( metadata );
+    metadata.calibration[0].XYZ_to_RGB_matrix = non_invertible_mat;
+    metadata.calibration[1].XYZ_to_RGB_matrix = non_invertible_mat;
+
+    std::vector<std::vector<double>> matrix;
+    bool                             success;
+    std::string                      error_message;
+    std::string                      output = capture_stderr( [&]() {
+        success = rta::util::fetch_matrix_from_metadata(
+            metadata, 1, false, matrix, error_message );
+    } );
+
+    OIIO_CHECK_ASSERT( !success );
+    OIIO_CHECK_EQUAL(
+        error_message,
+        "Failed to calculate transform matrix from DNG metadata. Failed to "
+        "find a suitable illuminant." );
+    OIIO_CHECK_EQUAL( matrix.size(), 0 );
 }
 
 /// Ensures missing camera data fails during illuminant-from-WB.
@@ -432,6 +472,7 @@ int main( int, char ** )
     test_fetch_multipliers_from_illuminant_failure_clears_output();
     test_fetch_matrix_from_illuminant_cache_hit();
     test_fetch_matrix_from_metadata_cache_hit_and_values();
+    test_fetch_matrix_from_metadata_failure_clears_output();
     test_fetch_illuminant_from_multipliers_missing_camera();
     test_fetch_matrix_from_illuminant_calculate_wb_failure();
 

--- a/tests/testDNGIdt.cpp
+++ b/tests/testDNGIdt.cpp
@@ -9,6 +9,7 @@
 #include "../src/rawtoaces_core/mathOps.h"
 #include "../src/rawtoaces_core/rawtoaces_core_priv.h"
 #include "test_utils.h"
+#include "../src/misc/pragma.h"
 
 void testIDT_CcttoMired()
 {
@@ -141,18 +142,20 @@ void check_DNG_matrix(
     std::vector<double>                    &neutralRGB,
     bool                                    expected_result,
     const std::vector<std::vector<double>> &expected_matrix,
-    const std::string                      &expected_output )
+    const std::string                      &expected_output,
+    const std::string                      &expected_error )
 {
     std::vector<std::vector<double>> camera_to_XYZ_matrix;
     bool                             result;
+    std::string                      error_message;
     std::string                      stderr_output = capture_stderr( [&]() {
         result = rta::core::find_camera_to_XYZ_matrix(
-            metadata, neutralRGB, camera_to_XYZ_matrix );
+            metadata, neutralRGB, camera_to_XYZ_matrix, error_message, 2 );
     } );
 
     OIIO_CHECK_EQUAL( result, expected_result );
-    if ( !expected_output.empty() )
-        OIIO_CHECK_EQUAL( stderr_output, expected_output );
+    OIIO_CHECK_EQUAL( stderr_output, expected_output );
+    OIIO_CHECK_EQUAL( error_message, expected_error );
 
     if ( result )
     {
@@ -191,7 +194,13 @@ void testIDT_FindCameraToXYZMtx()
 
     expected_matrix = rta::core::invertVM( expected_matrix );
 
-    check_DNG_matrix( metadata, neutralRGB, true, expected_matrix, "" );
+    check_DNG_matrix(
+        metadata,
+        neutralRGB,
+        true,
+        expected_matrix,
+        "Found illuminant: 5317k.\n",
+        "" );
 }
 
 void testIDT_FindCameraToXYZMtx_NoIlluminant()
@@ -212,7 +221,8 @@ void testIDT_FindCameraToXYZMtx_NoIlluminant()
         neutralRGB,
         true,
         m3,
-        "No calibration illuminants were found.\n" );
+        "No calibration illuminants were found.\n",
+        "" );
 }
 
 void testIDT_FindCameraToXYZMtx_EmptyNeutral()
@@ -228,7 +238,12 @@ void testIDT_FindCameraToXYZMtx_EmptyNeutral()
     auto m3 = rta::core::invertVM( m2 );
 
     check_DNG_matrix(
-        metadata, neutralRGB, true, m3, "No neutral RGB values were found.\n" );
+        metadata,
+        neutralRGB,
+        true,
+        m3,
+        "No neutral RGB values were found.\n",
+        "" );
 }
 
 void testIDT_FindCameraToXYZMtx_ExactMatchMired()
@@ -248,6 +263,7 @@ void testIDT_FindCameraToXYZMtx_ExactMatchMired()
         neutral_RGB,
         true,
         rta::core::stack_rows( k_identity_xyz_to_rgb, 3 ),
+        "Found illuminant: 10000k.\n",
         "" );
 }
 
@@ -272,7 +288,8 @@ void testIDT_FindCameraToXYZMtx_Fail()
         neutral_RGB,
         false,
         empty_mat,
-        "Failed to find a suitable illuminant.\n" );
+        "",
+        "Failed to find a suitable illuminant." );
 }
 void testIDT_ColorTemperatureToXYZ()
 {
@@ -304,10 +321,15 @@ void testIDT_GetCameraXYZWhitePoint_UsesIlluminantWhenNeutralEmpty()
 
     std::vector<std::vector<double>> camera_to_XYZ;
     std::vector<double>              camera_XYZ_white_point;
-    std::string                      stderr_output = capture_stderr( [&]() {
-        rta::core::get_camera_XYZ_matrix_and_white_point(
-            metadata, camera_to_XYZ, camera_XYZ_white_point );
+    std::string                      error_message;
+    bool                             success;
+
+    std::string stderr_output = capture_stderr( [&]() {
+        success = rta::core::get_camera_XYZ_matrix_and_white_point(
+            metadata, camera_to_XYZ, camera_XYZ_white_point, error_message, 2 );
     } );
+
+    OIIO_CHECK_ASSERT( success );
 
     // Expect illuminant 17 fallback (normalized Y=1.0) when neutral_RGB is empty.
     std::vector<double> expected = { 1.098445424569, 1.0, 0.355920076967 };
@@ -336,8 +358,9 @@ void testIDT_GetDNGCATMatrix()
     double matrix[3][3] = { { 0.9907763427, -0.0022862289, 0.0209908807 },
                             { -0.0017882434, 0.9941341374, 0.0083008330 },
                             { 0.0003777587, 0.0015609315, 1.1063201101 } };
+    DISABLE_DEPRECATED_WARNINGS
     std::vector<std::vector<double>> result = di->calculate_CAT_matrix();
-
+    ENABLE_WARNINGS
     delete di;
 
     for ( size_t i = 0; i < 3; i++ )
@@ -353,13 +376,60 @@ void testIDT_GetDNGIDTMatrix()
     double matrix[3][3] = { { 1.0536466144, 0.0039044182, 0.0049084502 },
                             { -0.4899562165, 1.3614787986, 0.1020844728 },
                             { -0.0024498461, 0.0060497128, 1.0139159537 } };
+    DISABLE_DEPRECATED_WARNINGS
     std::vector<std::vector<double>> result = di->calculate_IDT_matrix();
-
+    ENABLE_WARNINGS
     delete di;
 
     for ( size_t i = 0; i < 3; i++ )
         for ( size_t j = 0; j < 3; j++ )
             OIIO_CHECK_EQUAL_THRESH( result[i][j], matrix[i][j], 1e-5 );
+}
+
+void testIDT_GetDNGTransformMatrix()
+{
+    rta::core::Metadata metadata;
+    init_metadata( metadata );
+    rta::core::MetadataSolver solver( metadata );
+    double matrix[3][3] = { { 1.0536466144, 0.0039044182, 0.0049084502 },
+                            { -0.4899562165, 1.3614787986, 0.1020844728 },
+                            { -0.0024498461, 0.0060497128, 1.0139159537 } };
+    bool   result       = solver.calculate_transform();
+    std::vector<std::vector<double>> &transform_matrix =
+        solver.transform_matrix;
+
+    OIIO_CHECK_ASSERT( result );
+    for ( size_t i = 0; i < 3; i++ )
+        for ( size_t j = 0; j < 3; j++ )
+            OIIO_CHECK_EQUAL_THRESH(
+                transform_matrix[i][j], matrix[i][j], 1e-5 );
+}
+
+void testIDT_calculate_transform_Fail()
+{
+    std::vector<double> non_invertible_mat = { 1, 0, 0, 1, 0, 0, 1, 0, 0 };
+
+    std::vector<std::vector<double>> empty_mat;
+
+    std::vector<double> neutral_RGB = { 0.97347064038736957,
+                                        1.0,
+                                        1.4953965764168315 };
+
+    rta::core::Metadata metadata;
+    init_metadata( metadata );
+    metadata.calibration[0].XYZ_to_RGB_matrix = non_invertible_mat;
+    metadata.calibration[1].XYZ_to_RGB_matrix = non_invertible_mat;
+    metadata.calibration[1].illuminant        = 32768 + 10000;
+    metadata.neutral_RGB                      = neutral_RGB;
+
+    rta::core::MetadataSolver solver( metadata );
+
+    bool success = solver.calculate_transform();
+
+    OIIO_CHECK_ASSERT( !success );
+    OIIO_CHECK_EQUAL(
+        solver.last_error_message, "Failed to find a suitable illuminant." );
+    OIIO_CHECK_EQUAL( solver.transform_matrix.size(), 0 );
 }
 
 int main( int, char ** )
@@ -384,6 +454,8 @@ int main( int, char ** )
     testIDT_MatrixRGBtoXYZ();
     testIDT_GetDNGCATMatrix();
     testIDT_GetDNGIDTMatrix();
+    testIDT_GetDNGTransformMatrix();
+    testIDT_calculate_transform_Fail();
 
     return unit_test_failures;
 }

--- a/tests/testIDT.cpp
+++ b/tests/testIDT.cpp
@@ -13,11 +13,14 @@
 #include <rawtoaces/rawtoaces_core.h>
 #include "../src/rawtoaces_core/rawtoaces_core_priv.h"
 #include "test_utils.h"
+#include "../src/misc/pragma.h"
 
 #define DATA_PATH "../_deps/rawtoaces_data-src/data/"
 
 void testIDT_LoadCameraSpst()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::filesystem::path absolutePath =
         std::filesystem::absolute( DATA_PATH "camera/ARRI_D21_380_780_5.json" );
 
@@ -132,6 +135,8 @@ void testIDT_LoadCameraSpst()
 
 void testIDT_LoadIlluminant()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::filesystem::path absolutePath = std::filesystem::absolute(
         DATA_PATH "illuminant/iso7589_stutung_380_780_5.json" );
 
@@ -175,6 +180,8 @@ void testIDT_LoadIlluminant()
 
 void testIDT_LoadTrainingData()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::filesystem::path absolutePath = std::filesystem::absolute(
         DATA_PATH "training/training_spectral.json" );
 
@@ -278,6 +285,8 @@ void testIDT_LoadTrainingData()
 
 void testIDT_LoadCMF()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::filesystem::path absolutePath =
         std::filesystem::absolute( DATA_PATH "cmf/cmf_1931.json" );
 
@@ -743,6 +752,8 @@ void load_file( const std::string &path, rta::core::SpectralData &data )
 
 void testIDT_scaleLSC()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralData illuminant;
     load_file( "illuminant/iso7589_stutung_380_780_5.json", illuminant );
 
@@ -786,6 +797,8 @@ void testIDT_scaleLSC()
 
 void testIDT_CalCM()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralData illuminant;
     load_file( "illuminant/iso7589_stutung_380_780_5.json", illuminant );
 
@@ -802,6 +815,8 @@ void testIDT_CalCM()
 
 void testIDT_CalWB()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralData illuminant;
     load_file( "illuminant/iso7589_stutung_380_780_5.json", illuminant );
 
@@ -819,6 +834,8 @@ void testIDT_CalWB()
 
 void testIDT_ChooseIllumSrc()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralSolver solver( { DATA_PATH } );
     load_camera_helper( solver, "nikon", "d200", "", true, false );
 
@@ -857,6 +874,8 @@ void testIDT_ChooseIllumSrc()
 
 void testIDT_ChooseIllumType()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralSolver solver( { DATA_PATH } );
     load_camera_helper( solver, "nikon", "d200", "iso7589", true, false );
 
@@ -895,6 +914,8 @@ void testIDT_ChooseIllumType()
 
 void testIDT_CalTI()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralData camera;
     load_file( "camera/Nikon_D200_380_780_5.json", camera );
 
@@ -4809,6 +4830,8 @@ void testIDT_CalTI()
 
 void testIDT_CalXYZ()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralData camera;
     load_file( "camera/Nikon_D200_380_780_5.json", camera );
 
@@ -5024,6 +5047,8 @@ void testIDT_CalXYZ()
 
 void testIDT_CalRGB()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralData camera;
     load_file( "camera/Nikon_D200_380_780_5.json", camera );
 
@@ -5274,12 +5299,36 @@ void testIDT_CurveFit()
 
 void testIDT_CalIDT()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     rta::core::SpectralSolver solver( { DATA_PATH } );
     load_camera_helper( solver, "arri", "d21", "iso7589", true, true );
     solver.calculate_WB();
 
+    DISABLE_DEPRECATED_WARNINGS
     OIIO_CHECK_ASSERT( solver.calculate_IDT_matrix() );
     std::vector<std::vector<double>> IDT_test = solver.get_IDT_matrix();
+    ENABLE_WARNINGS
+
+    float IDT[3][3] = { { 1.0915120600f, -0.2516916464f, 0.1601795864f },
+                        { -0.0089998772f, 1.2147199060f, -0.2057200288f },
+                        { -0.1312667887f, -0.7361633199f, 1.8674301085f } };
+
+    for ( size_t i = 0; i < 3; i++ )
+        for ( size_t j = 0; j < 3; j++ )
+            OIIO_CHECK_EQUAL_THRESH( IDT[i][j], IDT_test[i][j], 1e-4 );
+}
+
+void testIDT_calculate_transform()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    rta::core::SpectralSolver solver( { DATA_PATH } );
+    load_camera_helper( solver, "arri", "d21", "iso7589", true, true );
+    solver.calculate_WB();
+
+    OIIO_CHECK_ASSERT( solver.calculate_transform() );
+    std::vector<std::vector<double>> &IDT_test = solver.transform_matrix;
 
     float IDT[3][3] = { { 1.0915120600f, -0.2516916464f, 0.1601795864f },
                         { -0.0089998772f, 1.2147199060f, -0.2057200288f },
@@ -5291,10 +5340,10 @@ void testIDT_CalIDT()
 }
 
 /// Helper function to test that calculate_IDT_matrix returns false and prints expected error
-static void check_calculate_IDT_matrix_error(
+static void check_calculate_transform_matrix_error(
     rta::core::SpectralSolver &solver, const std::string &expected_error )
 {
-    bool        success = solver.calculate_IDT_matrix();
+    bool        success = solver.calculate_transform();
     std::string output  = solver.last_error_message;
 
     OIIO_CHECK_ASSERT( !success );
@@ -5306,10 +5355,9 @@ const std::string expected_error_camera_not_initialized =
     "SpectralSolver::calculate_IDT_matrix().";
 
 /// Tests that calculate_IDT_matrix returns false and prints error when camera is not initialized
-void testIDT_CalIDT_Camera_Not_Initialized()
+void testIDT_calculate_transform_Camera_Not_Initialized()
 {
-    std::cout << std::endl
-              << "testIDT_CalIDT_Camera_Not_Initialized()" << std::endl;
+    std::cout << std::endl << __FUNCTION__ << std::endl;
 
     rta::core::SpectralSolver solver( { DATA_PATH } );
     /// Camera is not initialized - leave it empty
@@ -5323,14 +5371,14 @@ void testIDT_CalIDT_Camera_Not_Initialized()
     OIIO_CHECK_ASSERT( result );
     /// Cannot call calculate_WB() because camera is not initialized
 
-    check_calculate_IDT_matrix_error(
+    check_calculate_transform_matrix_error(
         solver, expected_error_camera_not_initialized );
 }
 
 /// Tests that calculate_IDT_matrix returns false and prints error when camera has wrong size
-void testIDT_CalIDT_Camera_Wrong_Size()
+void testIDT_calculate_transform_Camera_Wrong_Size()
 {
-    std::cout << std::endl << "testIDT_CalIDT_Camera_Wrong_Size()" << std::endl;
+    std::cout << std::endl << __FUNCTION__ << std::endl;
 
     rta::core::SpectralSolver solver( { DATA_PATH } );
     /// Initialize camera with wrong size (2 channels instead of 3)
@@ -5349,7 +5397,7 @@ void testIDT_CalIDT_Camera_Wrong_Size()
     OIIO_CHECK_ASSERT( result );
     solver.calculate_WB();
 
-    check_calculate_IDT_matrix_error(
+    check_calculate_transform_matrix_error(
         solver, expected_error_camera_not_initialized );
 }
 
@@ -5358,10 +5406,9 @@ const std::string expected_error_illuminant_not_initialized =
     "calling SpectralSolver::calculate_IDT_matrix().";
 
 /// Tests that calculate_IDT_matrix returns false and prints error when illuminant is not initialized
-void testIDT_CalIDT_Illuminant_Not_Initialized()
+void testIDT_calculate_transform_Illuminant_Not_Initialized()
 {
-    std::cout << std::endl
-              << "testIDT_CalIDT_Illuminant_Not_Initialized()" << std::endl;
+    std::cout << std::endl << __FUNCTION__ << std::endl;
 
     rta::core::SpectralSolver solver( { DATA_PATH } );
     /// Initialize camera
@@ -5376,15 +5423,14 @@ void testIDT_CalIDT_Illuminant_Not_Initialized()
     OIIO_CHECK_ASSERT( result );
     solver.calculate_WB();
 
-    check_calculate_IDT_matrix_error(
+    check_calculate_transform_matrix_error(
         solver, expected_error_illuminant_not_initialized );
 }
 
 /// Tests that calculate_IDT_matrix returns false and prints error when illuminant has wrong size
-void testIDT_CalIDT_Illuminant_Wrong_Size()
+void testIDT_calculate_transform_Illuminant_Wrong_Size()
 {
-    std::cout << std::endl
-              << "testIDT_CalIDT_Illuminant_Wrong_Size()" << std::endl;
+    std::cout << std::endl << __FUNCTION__ << std::endl;
 
     rta::core::SpectralSolver solver( { DATA_PATH } );
     /// Initialize camera
@@ -5405,7 +5451,7 @@ void testIDT_CalIDT_Illuminant_Wrong_Size()
     OIIO_CHECK_ASSERT( result );
     solver.calculate_WB();
 
-    check_calculate_IDT_matrix_error(
+    check_calculate_transform_matrix_error(
         solver, expected_error_illuminant_not_initialized );
 }
 
@@ -5414,10 +5460,9 @@ const std::string expected_error_observer_not_initialized =
     "SpectralSolver::calculate_IDT_matrix().";
 
 /// Tests that calculate_IDT_matrix returns false and prints error when observer is not initialized
-void testIDT_CalIDT_Observer_Not_Initialized()
+void testIDT_calculate_transform_Observer_Not_Initialized()
 {
-    std::cout << std::endl
-              << "testIDT_CalIDT_Observer_Not_Initialized()" << std::endl;
+    std::cout << std::endl << __FUNCTION__ << std::endl;
 
     rta::core::SpectralSolver solver( { DATA_PATH } );
     /// Initialize camera, illuminant, but not observer
@@ -5426,15 +5471,14 @@ void testIDT_CalIDT_Observer_Not_Initialized()
     solver.observer.data.clear();
     solver.calculate_WB();
 
-    check_calculate_IDT_matrix_error(
+    check_calculate_transform_matrix_error(
         solver, expected_error_observer_not_initialized );
 }
 
 /// Tests that calculate_IDT_matrix returns false and prints error when observer has wrong size
-void testIDT_CalIDT_Observer_Wrong_Size()
+void testIDT_calculate_transform_Observer_Wrong_Size()
 {
-    std::cout << std::endl
-              << "testIDT_CalIDT_Observer_Wrong_Size()" << std::endl;
+    std::cout << std::endl << __FUNCTION__ << std::endl;
 
     rta::core::SpectralSolver solver( { DATA_PATH } );
     /// Initialize camera, illuminant
@@ -5448,7 +5492,7 @@ void testIDT_CalIDT_Observer_Wrong_Size()
     OIIO_CHECK_EQUAL( solver.observer.data["main"].size(), 2 );
     solver.calculate_WB();
 
-    check_calculate_IDT_matrix_error(
+    check_calculate_transform_matrix_error(
         solver, expected_error_observer_not_initialized );
 }
 
@@ -5457,10 +5501,9 @@ const std::string expected_error_training_data_not_initialized =
     "calling SpectralSolver::calculate_IDT_matrix().";
 
 /// Tests that calculate_IDT_matrix returns false and prints error when training data is not initialized
-void testIDT_CalIDT_Training_Data_Not_Initialized()
+void testIDT_calculate_transform_Training_Data_Not_Initialized()
 {
-    std::cout << std::endl
-              << "testIDT_CalIDT_Training_Data_Not_Initialized()" << std::endl;
+    std::cout << std::endl << __FUNCTION__ << std::endl;
 
     rta::core::SpectralSolver solver( { DATA_PATH } );
     /// Initialize camera, illuminant, observer, but not training_data
@@ -5469,15 +5512,14 @@ void testIDT_CalIDT_Training_Data_Not_Initialized()
     solver.training_data.data.clear();
     solver.calculate_WB();
 
-    check_calculate_IDT_matrix_error(
+    check_calculate_transform_matrix_error(
         solver, expected_error_training_data_not_initialized );
 }
 
 /// Tests that calculate_IDT_matrix returns false and prints error when training data is empty
-void testIDT_CalIDT_Training_Data_Empty()
+void testIDT_calculate_transform_Training_Data_Empty()
 {
-    std::cout << std::endl
-              << "testIDT_CalIDT_Training_Data_Empty()" << std::endl;
+    std::cout << std::endl << __FUNCTION__ << std::endl;
 
     rta::core::SpectralSolver solver( { DATA_PATH } );
     /// Initialize camera, illuminant, observer
@@ -5492,7 +5534,7 @@ void testIDT_CalIDT_Training_Data_Empty()
     OIIO_CHECK_EQUAL( solver.training_data.data["main"].empty(), true );
     solver.calculate_WB();
 
-    check_calculate_IDT_matrix_error(
+    check_calculate_transform_matrix_error(
         solver, expected_error_training_data_not_initialized );
 }
 
@@ -5512,14 +5554,15 @@ int main( int, char ** )
     testIDT_CalRGB();
     testIDT_CurveFit();
     testIDT_CalIDT();
-    testIDT_CalIDT_Camera_Not_Initialized();
-    testIDT_CalIDT_Camera_Wrong_Size();
-    testIDT_CalIDT_Illuminant_Not_Initialized();
-    testIDT_CalIDT_Illuminant_Wrong_Size();
-    testIDT_CalIDT_Observer_Not_Initialized();
-    testIDT_CalIDT_Observer_Wrong_Size();
-    testIDT_CalIDT_Training_Data_Not_Initialized();
-    testIDT_CalIDT_Training_Data_Empty();
+    testIDT_calculate_transform();
+    testIDT_calculate_transform_Camera_Not_Initialized();
+    testIDT_calculate_transform_Camera_Wrong_Size();
+    testIDT_calculate_transform_Illuminant_Not_Initialized();
+    testIDT_calculate_transform_Illuminant_Wrong_Size();
+    testIDT_calculate_transform_Observer_Not_Initialized();
+    testIDT_calculate_transform_Observer_Wrong_Size();
+    testIDT_calculate_transform_Training_Data_Not_Initialized();
+    testIDT_calculate_transform_Training_Data_Empty();
 
     return unit_test_failures;
 }

--- a/tests/test_image_converter.cpp
+++ b/tests/test_image_converter.cpp
@@ -1798,7 +1798,7 @@ void test_idt_verbosity_level_1()
     // Calculate IDT matrix and capture stderr
     bool        success;
     std::string output =
-        capture_stderr( [&]() { success = solver.calculate_IDT_matrix(); } );
+        capture_stderr( [&]() { success = solver.calculate_transform(); } );
 
     OIIO_CHECK_ASSERT( success );
 
@@ -1846,7 +1846,7 @@ void test_idt_verbosity_level_2()
     // Calculate IDT matrix and capture stderr
     bool        success;
     std::string output =
-        capture_stderr( [&]() { success = solver.calculate_IDT_matrix(); } );
+        capture_stderr( [&]() { success = solver.calculate_transform(); } );
 
     OIIO_CHECK_ASSERT( success );
 
@@ -1854,7 +1854,7 @@ void test_idt_verbosity_level_2()
     ASSERT_NOT_CONTAINS( output, "Solver Summary" );
 
     // Verify IDT matrix was calculated successfully
-    const auto &IDT_matrix = solver.get_IDT_matrix();
+    const auto &IDT_matrix = solver.transform_matrix;
     OIIO_CHECK_EQUAL( IDT_matrix.size(), 3 );
     OIIO_CHECK_EQUAL( IDT_matrix[0].size(), 3 );
     OIIO_CHECK_EQUAL( IDT_matrix[1].size(), 3 );
@@ -1900,7 +1900,7 @@ void test_idt_verbosity_level_3()
     // Calculate IDT matrix and capture stderr
     bool        success;
     std::string output =
-        capture_stderr( [&]() { success = solver.calculate_IDT_matrix(); } );
+        capture_stderr( [&]() { success = solver.calculate_transform(); } );
 
     OIIO_CHECK_ASSERT( success );
 
@@ -1908,7 +1908,7 @@ void test_idt_verbosity_level_3()
     ASSERT_CONTAINS( output, "Solver Summary" );
 
     // Verify IDT matrix was calculated successfully
-    const auto &IDT_matrix = solver.get_IDT_matrix();
+    const auto &IDT_matrix = solver.transform_matrix;
     OIIO_CHECK_EQUAL( IDT_matrix.size(), 3 );
     OIIO_CHECK_EQUAL( IDT_matrix[0].size(), 3 );
     OIIO_CHECK_EQUAL( IDT_matrix[1].size(), 3 );
@@ -1961,7 +1961,7 @@ void test_idt_curvefit_failure_returns_false()
 
     bool        success;
     std::string output =
-        capture_stderr( [&]() { success = solver.calculate_IDT_matrix(); } );
+        capture_stderr( [&]() { success = solver.calculate_transform(); } );
 
     // Optimization should fail and return false
     OIIO_CHECK_ASSERT( !success );

--- a/tests/test_image_converter.cpp
+++ b/tests/test_image_converter.cpp
@@ -1088,6 +1088,37 @@ void test_fallback_to_metadata()
         output, "Missing the camera model name in the file metadata" );
 }
 
+void check_prepare_transform_spectral(
+    const OIIO::ImageSpec                     &image_spec,
+    const rta::util::ImageConverter::Settings &settings,
+    std::vector<double>                        WB_multipliers,
+    bool                                       expected_result,
+    const std::string                         &expected_error,
+    const std::vector<std::string>            &expected_warnings )
+{
+    bool                             success;
+    std::string                      error_message;
+    std::vector<std::vector<double>> transform_matrix;
+
+    std::string output = capture_stderr( [&]() {
+        // This should succeed and auto-detect the illuminant
+        success = prepare_transform_spectral(
+            image_spec,
+            settings,
+            WB_multipliers,
+            transform_matrix,
+            error_message );
+    } );
+
+    OIIO_CHECK_EQUAL( success, expected_result );
+    ASSERT_CONTAINS( error_message, expected_error );
+
+    for ( const auto &warning: expected_warnings )
+    {
+        ASSERT_CONTAINS( output, warning );
+    }
+}
+
 /// Tests that prepare_transform_spectral fails when no camera manufacturer information is available (should fail)
 void test_missing_camera_manufacturer()
 {
@@ -1105,27 +1136,15 @@ void test_missing_camera_manufacturer()
         SettingsBuilder().database( test_dir.get_database_path() ).build();
 
     // Test: Empty camera make via direct method call
-    std::vector<double>              WB_multipliers;
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
+    std::vector<double> WB_multipliers;
 
-    // Call prepare_transform_spectral - error should be in error_message parameter
-    bool        success;
-    std::string error_message;
-    success = prepare_transform_spectral(
+    check_prepare_transform_spectral(
         image_spec,
         settings,
         WB_multipliers,
-        IDT_matrix,
-        CAT_matrix,
-        error_message );
-
-    OIIO_CHECK_ASSERT( !success );
-
-    // Assert on the expected error message in the error_message parameter
-    ASSERT_CONTAINS(
-        error_message,
-        "Missing the camera manufacturer name in the file metadata" );
+        false,
+        "Missing the camera manufacturer name in the file metadata",
+        {} );
 }
 
 /// Tests that conversion fails when camera model is missing (should fail)
@@ -1298,25 +1317,15 @@ void test_illuminant_type_not_found()
             .build();
 
     // Test: Request an illuminant type that doesn't exist in the illuminant data
-    std::vector<double>              WB_multipliers;
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
+    std::vector<double> WB_multipliers;
 
-    // Call prepare_transform_spectral - error should be in error_message parameter
-    bool        success;
-    std::string error_message;
-    success = prepare_transform_spectral(
+    check_prepare_transform_spectral(
         image_spec,
         settings,
         WB_multipliers,
-        IDT_matrix,
-        CAT_matrix,
-        error_message );
-
-    OIIO_CHECK_ASSERT( !success );
-
-    // Assert on the expected error message in the error_message parameter
-    ASSERT_CONTAINS( error_message, "Failed to find illuminant type 'a'" );
+        false,
+        "Failed to find illuminant type 'a'",
+        {} );
 }
 
 /// Tests that invalid daylight color temperature values cause the application to exit with an error
@@ -1422,28 +1431,16 @@ void test_auto_detect_illuminant_with_wb_multipliers()
 
     // Provide WB_multipliers with size 4 to exercise the 4-channel path
     std::vector<double> WB_multipliers = { 1.5, 1.0, 1.2, 1.0 }; // 4 channels
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
 
-    bool        success;
-    std::string error_message;
-    std::string output = capture_stderr( [&]() {
-        // This should succeed and auto-detect the illuminant
-        success = prepare_transform_spectral(
-            image_spec,
-            settings,
-            WB_multipliers,
-            IDT_matrix,
-            CAT_matrix,
-            error_message );
-    } );
-
-    OIIO_CHECK_ASSERT( success );
-
-    // Assert on expected messages
-    ASSERT_CONTAINS( output, "Warning: Directory '" );
-    ASSERT_CONTAINS( output, "illuminant' does not exist." );
-    ASSERT_CONTAINS( output, "Found illuminant: '2000k'." );
+    check_prepare_transform_spectral(
+        image_spec,
+        settings,
+        WB_multipliers,
+        true,
+        "",
+        { "Warning: Directory '",
+          "illuminant' does not exist.",
+          "Found illuminant: '2000k'." } );
 }
 
 /// Tests that a warning is issued when a database location path points to a file instead of a directory
@@ -1478,29 +1475,15 @@ void test_database_location_not_directory_warning()
     settings.disable_cache = true;
 
     // Provide WB_multipliers
-    std::vector<double>              WB_multipliers = { 1.5, 1.0, 1.2, 1.0 };
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
+    std::vector<double> WB_multipliers = { 1.5, 1.0, 1.2, 1.0 };
 
-    bool        success;
-    std::string error_message;
-    std::string output = capture_stderr( [&]() {
-        // This should succeed (using the valid database path)
-        // but should warn about the file path not being a directory
-        success = prepare_transform_spectral(
-            image_spec,
-            settings,
-            WB_multipliers,
-            IDT_matrix,
-            CAT_matrix,
-            error_message );
-    } );
-
-    OIIO_CHECK_ASSERT( success );
-
-    // Assert on expected warning
-    ASSERT_CONTAINS( output, "Warning: Database location '" );
-    ASSERT_CONTAINS( output, "' is not a directory." );
+    check_prepare_transform_spectral(
+        image_spec,
+        settings,
+        WB_multipliers,
+        true,
+        "",
+        { "Warning: Database location '", "' is not a directory." } );
 
     // Clean up the test file
     std::filesystem::remove( file_path );
@@ -1535,29 +1518,15 @@ void test_database_location_missing_warning()
     settings.disable_cache = true;
 
     // Provide WB_multipliers
-    std::vector<double>              WB_multipliers = { 1.5, 1.0, 1.2, 1.0 };
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
+    std::vector<double> WB_multipliers = { 1.5, 1.0, 1.2, 1.0 };
 
-    bool        success;
-    std::string error_message;
-    std::string output = capture_stderr( [&]() {
-        // This should succeed (using the valid database path)
-        // but should warn about the file path not being a directory
-        success = prepare_transform_spectral(
-            image_spec,
-            settings,
-            WB_multipliers,
-            IDT_matrix,
-            CAT_matrix,
-            error_message );
-    } );
-
-    OIIO_CHECK_ASSERT( success );
-
-    // Assert on expected warning
-    ASSERT_CONTAINS( output, "Warning: Database location '" );
-    ASSERT_CONTAINS( output, "' does not exist." );
+    check_prepare_transform_spectral(
+        image_spec,
+        settings,
+        WB_multipliers,
+        true,
+        "",
+        { "Warning: Database location '", "' does not exist." } );
 }
 
 /// Tests that spectral data can be loaded using an absolute file path
@@ -1630,24 +1599,15 @@ void test_illuminant_file_load_failure()
                         .illuminant( "nonexistent_type" )
                         .build();
 
-    std::vector<double>              WB_multipliers;
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
+    std::vector<double> WB_multipliers;
 
-    bool        success;
-    std::string error_message;
-    success = prepare_transform_spectral(
+    check_prepare_transform_spectral(
         image_spec,
         settings,
         WB_multipliers,
-        IDT_matrix,
-        CAT_matrix,
-        error_message );
-
-    // Should fail (no matching type found), but invalid file should have been processed and skipped
-    OIIO_CHECK_ASSERT( !success );
-    ASSERT_CONTAINS(
-        error_message, "Failed to find illuminant type 'nonexistent_type'" );
+        false,
+        "Failed to find illuminant type 'nonexistent_type'",
+        {} );
 }
 
 /// Tests that invalid illuminant files are skipped when populating all illuminants for auto-detection
@@ -1991,22 +1951,15 @@ void test_illuminant_type_mismatch()
                         .illuminant( "typeC" ) // Different from typeA and typeB
                         .build();
 
-    std::vector<double>              WB_multipliers;
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
+    std::vector<double> WB_multipliers;
 
-    bool        success;
-    std::string error_message;
-    success = prepare_transform_spectral(
+    check_prepare_transform_spectral(
         image_spec,
         settings,
         WB_multipliers,
-        IDT_matrix,
-        CAT_matrix,
-        error_message );
-
-    OIIO_CHECK_ASSERT( !success );
-    ASSERT_CONTAINS( error_message, "Failed to find illuminant type 'typec'" );
+        false,
+        "Failed to find illuminant type 'typec'",
+        {} );
 }
 
 /// Tests that blackbody illuminant strings (e.g., "3200K") are correctly processed
@@ -2078,26 +2031,14 @@ void test_auto_detect_illuminant_from_raw_metadata()
     // Provide empty WB_multipliers to trigger extraction from raw:pre_mul
     std::vector<double>
         WB_multipliers; // Empty - will trigger raw:pre_mul extraction
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
 
-    bool        success;
-    std::string error_message;
-    std::string output = capture_stderr( [&]() {
-        // This should succeed and auto-detect the illuminant from raw:pre_mul
-        success = prepare_transform_spectral(
-            image_spec,
-            settings,
-            WB_multipliers,
-            IDT_matrix,
-            CAT_matrix,
-            error_message );
-    } );
-
-    OIIO_CHECK_ASSERT( success );
-
-    // Verify the "Found illuminant:" message appears
-    ASSERT_CONTAINS( output, "Found illuminant: '2000k'." );
+    check_prepare_transform_spectral(
+        image_spec,
+        settings,
+        WB_multipliers,
+        true,
+        "",
+        { "Found illuminant: '2000k'." } );
 }
 
 /// Tests that auto-detection normalizes white balance multipliers when min_val > 0 and != 1
@@ -2129,26 +2070,14 @@ void test_auto_detect_illuminant_with_normalization()
     // Provide empty WB_multipliers to trigger extraction from raw:pre_mul
     std::vector<double>
         WB_multipliers; // Empty - will trigger raw:pre_mul extraction
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
 
-    bool        success;
-    std::string error_message;
-    std::string output = capture_stderr( [&]() {
-        // This should succeed and auto-detect the illuminant from raw:pre_mul
-        success = prepare_transform_spectral(
-            image_spec,
-            settings,
-            WB_multipliers,
-            IDT_matrix,
-            CAT_matrix,
-            error_message );
-    } );
-
-    OIIO_CHECK_ASSERT( success );
-
-    // Verify the "Found illuminant:" message appears
-    ASSERT_CONTAINS( output, "Found illuminant: '1500k'." );
+    check_prepare_transform_spectral(
+        image_spec,
+        settings,
+        WB_multipliers,
+        true,
+        "",
+        { "Found illuminant: '1500k'." } );
 }
 
 /// Tests that prepare_transform_spectral fails when IDT matrix calculation fails
@@ -2193,28 +2122,17 @@ void test_prepare_transform_spectral_idt_calculation_fail()
         SettingsBuilder().database( test_dir.get_database_path() ).build();
 
     // Provide WB_multipliers
-    std::vector<double>              WB_multipliers = { 1.5, 1.0, 1.2 };
-    std::vector<std::vector<double>> IDT_matrix;
-    std::vector<std::vector<double>> CAT_matrix;
+    std::vector<double> WB_multipliers = { 1.5, 1.0, 1.2 };
 
-    bool        success;
-    std::string error_message;
-    success = prepare_transform_spectral(
+    check_prepare_transform_spectral(
         image_spec,
         settings,
         WB_multipliers,
-        IDT_matrix,
-        CAT_matrix,
-        error_message );
-
-    OIIO_CHECK_ASSERT( !success );
-
-    // Verify the error message about failed IDT matrix calculation
-    ASSERT_CONTAINS(
-        error_message,
+        false,
         "Failed to calculate IDT matrix from illuminant. "
         "Training data needs to be initialised prior to calling "
-        "SpectralSolver::calculate_IDT_matrix()." );
+        "SpectralSolver::calculate_IDT_matrix().",
+        {} );
 }
 
 /// Tests that conversion succeeds when all required data is present

--- a/tests/usage_example_core.cpp
+++ b/tests/usage_example_core.cpp
@@ -48,11 +48,11 @@ void test_SpectralSolver_multipliers()
     solver.find_illuminant( white_balance );
 
     // Step 2: Solve the transform matrix.
-    solver.calculate_IDT_matrix();
+    solver.calculate_transform();
 
     // Step 3: Get the solved matrix.
     const std::vector<std::vector<double>> &solved_IDT =
-        solver.get_IDT_matrix();
+        solver.transform_matrix;
 
     // Check the results.
     const std::vector<std::vector<double>> true_IDT = {
@@ -88,11 +88,11 @@ void test_SpectralSolver_illuminant()
     const std::vector<double> &solved_WB = solver.get_WB_multipliers();
 
     // Step 4: Solve the transform matrix.
-    solver.calculate_IDT_matrix();
+    solver.calculate_transform();
 
     // Step 5: Get the solved matrix.
     const std::vector<std::vector<double>> &solved_IDT =
-        solver.get_IDT_matrix();
+        solver.transform_matrix;
 
     // Check the results.
     const std::vector<double> true_WB = { 1.79488, 1, 1.39779 };
@@ -121,8 +121,11 @@ void test_MetadataSolver()
     rta::core::MetadataSolver solver( metadata );
 
     // Step 2: Solve the transform matrix.
-    const std::vector<std::vector<double>> solved_IDT =
-        solver.calculate_IDT_matrix();
+    solver.calculate_transform();
+
+    // Step 3: Get the solved matrix.
+    const std::vector<std::vector<double>> &solved_IDT =
+        solver.transform_matrix;
 
     // Check the results.
     const std::vector<std::vector<double>> true_IDT = {


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Implement a new class rta::core::TransformSolver which is now a base class for both `rta::core::SpectralSolver` and `rta::core::MetadataSolver`. The methods for calculating the transform and accessing the solved matrix are now uniform across the two.

The MetadataSolver class has got some additional error reporting.

This also deprecates the `calculate_IDT_matrix` and `calculate_CAT_matrix` across all classes in favour of a more generic `calculate_transform`.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
