### PR TITLE
[fix] custom WB weights in DNG mode

### DIFF
--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -512,6 +512,7 @@ bool prepare_transform_spectral(
 bool prepare_transform_DNG(
     const OIIO::ImageSpec            &image_spec,
     const ImageConverter::Settings   &settings,
+    const std::vector<double>        &wb_multipliers,
     std::vector<std::vector<double>> &IDT_matrix,
     std::vector<std::vector<double>> &CAT_matrix,
     std::string                      &error_message )
@@ -526,15 +527,30 @@ bool prepare_transform_DNG(
         image_spec.get_float_attribute( "raw:dng:baseline_exposure" ) );
 
     // Step 2: Extract neutral RGB values from camera multipliers
-    metadata.neutral_RGB.resize( 3 );
-
-    auto attr = image_spec.find_attribute(
-        "raw:cam_mul", OIIO::TypeDesc( OIIO::TypeDesc::FLOAT, 4 ) );
-    if ( attr )
+    if ( wb_multipliers.size() == 4 )
     {
-        for ( int i = 0; i < 3; i++ )
-            metadata.neutral_RGB[i] =
-                1.0 / static_cast<double>( attr->get_float_indexed( i ) );
+        double r  = wb_multipliers[0];
+        double g  = wb_multipliers[1];
+        double b  = wb_multipliers[2];
+        double g2 = wb_multipliers[3];
+
+        if ( std::abs( g2 ) > 1e-9 )
+        {
+            g = ( g + g2 ) * 0.5;
+        }
+
+        assert( std::abs( r ) > 1e-9 );
+        assert( std::abs( g ) > 1e-9 );
+        assert( std::abs( b ) > 1e-9 );
+
+        metadata.neutral_RGB.resize( 3 );
+        metadata.neutral_RGB[0] = 1.0 / r;
+        metadata.neutral_RGB[1] = 1.0 / g;
+        metadata.neutral_RGB[2] = 1.0 / b;
+    }
+    else
+    {
+        metadata.neutral_RGB.resize( 0 );
     }
 
     // Step 3: Extract calibration data for two illuminants
@@ -1904,8 +1920,13 @@ bool ImageConverter::configure(
             settings.chromatic_aberration );
     }
 
-    bool is_DNG =
-        image_spec.extra_attribs.find( "raw:dng:version" )->get_int() > 0;
+    bool is_DNG                = false;
+    auto dng_version_attribute = image_spec.find_attribute(
+        "raw:dng:version", OIIO::TypeDesc( OIIO::TypeDesc::INT ) );
+    if ( dng_version_attribute )
+    {
+        is_DNG = dng_version_attribute->get_int() > 0;
+    }
 
     bool require_spectral =
         settings.WB_method == Settings::WBMethod::Illuminant ||
@@ -2115,12 +2136,12 @@ bool ImageConverter::configure(
         if ( is_DNG )
         {
             options["raw:use_camera_matrix"] = 1;
-            options["raw:use_camera_wb"]     = 1;
 
             std::string error_msg;
             if ( !prepare_transform_DNG(
                      image_spec,
                      settings,
+                     _wb_multipliers,
                      _idt_matrix,
                      _cat_matrix,
                      error_msg ) )

--- a/tests/test_image_converter.cpp
+++ b/tests/test_image_converter.cpp
@@ -2973,6 +2973,54 @@ void test_lens_correction_type()
         rta::util::ImageConverter::Settings::LensCorrectionType::Aberration ) );
 }
 
+void test_metadata_wb_being_set()
+{
+    // Set the WB multipliers in the image spec, as if they came from an
+    // image file.
+    float           wb[4] = { 2.0f, 1.0f, 1.5f, 1.2f };
+    OIIO::ImageSpec spec;
+    spec.extra_attribs.attribute(
+        "raw:cam_mul", OIIO::TypeDesc( OIIO::TypeDesc::FLOAT, 4 ), wb );
+
+    rta::util::ImageConverter converter;
+    converter.settings.WB_method =
+        rta::util::ImageConverter::Settings::WBMethod::Metadata;
+
+    OIIO::ParamValueList hints;
+    bool                 success        = converter.configure( spec, hints );
+    const auto          &wb_multipliers = converter.get_WB_multipliers();
+
+    OIIO_CHECK_ASSERT( success );
+    OIIO_CHECK_EQUAL( wb_multipliers.size(), 4 );
+    OIIO_CHECK_EQUAL_THRESH( wb_multipliers[0], 2.0f, 1e-5 );
+    OIIO_CHECK_EQUAL_THRESH( wb_multipliers[1], 1.0f, 1e-5 );
+    OIIO_CHECK_EQUAL_THRESH( wb_multipliers[2], 1.5f, 1e-5 );
+    OIIO_CHECK_EQUAL_THRESH( wb_multipliers[3], 1.2f, 1e-5 );
+}
+
+void test_custom_wb_being_set()
+{
+    rta::util::ImageConverter converter;
+    converter.settings.WB_method =
+        rta::util::ImageConverter::Settings::WBMethod::Custom;
+    converter.settings.custom_WB[0] = 2.0f;
+    converter.settings.custom_WB[1] = 1.0f;
+    converter.settings.custom_WB[2] = 1.5f;
+    converter.settings.custom_WB[3] = 1.2f;
+
+    OIIO::ImageSpec      spec;
+    OIIO::ParamValueList hints;
+    bool                 success        = converter.configure( spec, hints );
+    const auto          &wb_multipliers = converter.get_WB_multipliers();
+
+    OIIO_CHECK_ASSERT( success );
+    OIIO_CHECK_EQUAL( wb_multipliers.size(), 4 );
+    OIIO_CHECK_EQUAL_THRESH( wb_multipliers[0], 2.0f, 1e-5 );
+    OIIO_CHECK_EQUAL_THRESH( wb_multipliers[1], 1.0f, 1e-5 );
+    OIIO_CHECK_EQUAL_THRESH( wb_multipliers[2], 1.5f, 1e-5 );
+    OIIO_CHECK_EQUAL_THRESH( wb_multipliers[3], 1.2f, 1e-5 );
+}
+
 int main( int, char ** )
 {
     try
@@ -3086,6 +3134,9 @@ int main( int, char ** )
         test_main_output_directory_error_hint();
         test_main_error_message_without_hint();
         test_main_error_data_dir_hint();
+
+        test_metadata_wb_being_set();
+        test_custom_wb_being_set();
 
         // Tests for lens correction types
         test_lens_correction_type();


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Allow custom white-balancing weights being used in DNG mode.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
