### PR TITLE
[refactor] make eigen optional

### DIFF
--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -33,6 +33,9 @@ on:
       enable_lensfun:
         type: string
         default: 'ON'
+      enable_eigen:
+        type: string
+        default: 'ON'
       vfxyear:
         type: number
         default: 0
@@ -127,6 +130,7 @@ jobs:
           -D CMAKE_BUILD_TYPE="${{ inputs.build_type }}"
           -D ENABLE_SHARED="${{ inputs.build_shared_libs }}"
           -D RTA_ENABLE_LENSFUN="${{ inputs.enable_lensfun }}"
+          -D RTA_ENABLE_EIGEN="${{ inputs.enable_eigen }}"
           -D RTA_SANITISER_MODE="${{ inputs.sanitiser_mode }}"
           
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,17 +65,22 @@ jobs:
       install_deps: install_deps_${{ matrix.os }}
       toolchain_file: ${{ matrix.toolchain_file }}
       build_shared_libs: ${{ matrix.build_shared_libs || 'ON' }}
-      enable_lensfun: ${{ matrix.lensfun }}
-      cxx_standard: 20
-      workflow_name: "lensfun-${{matrix.lensfun}}"
-
+      workflow_name: ${{matrix.options[0]}}
+      enable_eigen: ${{ matrix.options[1] }}
+      enable_lensfun: ${{ matrix.options[2] }}
+      cxx_standard: 17
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
       fail-fast: false
 
       matrix:
         os: [ macos, ubuntu, windows ]
-        lensfun: [ OFF, ON ]
+        options: [
+          # [ name, enable_eigen, enable_lensfun]
+          ["minimal", OFF, OFF],
+          ["eigen",   ON,  OFF],
+          ["full",    ON,  ON ]
+        ]
         include:
           - os: windows
             c_compiler: cl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ option( RTA_BUILD_TESTS "Build unit tests" ON )
 option( RTA_INSTALL_DATABASE "Download and install the spectral measurements database" ON )
 option( ENABLE_COVERAGE "Enable code coverage reporting" OFF )
 option( RTA_ENABLE_LENSFUN "Use lensfun for lens correction" ON )
+option( RTA_ENABLE_EIGEN "Use Eigen for linear algebra" ON )
 set ( RTA_SANITISER_MODE "none" CACHE STRING "Dynamic analysis sanitiser mode ('none', 'address', 'memory', or 'thread')" )
 
 if ( ENABLE_SHARED )

--- a/config/RAWTOACESConfig.cmake.in
+++ b/config/RAWTOACESConfig.cmake.in
@@ -8,7 +8,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/RAWTOACESTargets.cmake)
 
 include(CMakeFindDependencyMacro)
 
-find_dependency ( Eigen3 )
+if ( @RTA_ENABLE_EIGEN@ )
+    find_dependency ( Eigen3 )
+endif
 find_dependency ( Ceres )
 find_dependency ( OpenImageIO )
 

--- a/config/RAWTOACESConfig.cmake.in
+++ b/config/RAWTOACESConfig.cmake.in
@@ -10,7 +10,7 @@ include(CMakeFindDependencyMacro)
 
 if ( @RTA_ENABLE_EIGEN@ )
     find_dependency ( Eigen3 )
-endif
+endif ()
 find_dependency ( Ceres )
 find_dependency ( OpenImageIO )
 

--- a/configure.cmake
+++ b/configure.cmake
@@ -4,7 +4,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_INSTALL_PREFIX}/share/CMake"
 
 find_package ( nlohmann_json CONFIG REQUIRED )
 find_package ( OpenImageIO   CONFIG REQUIRED )
-find_package ( Eigen3        CONFIG REQUIRED )
+
+if ( RTA_ENABLE_EIGEN )
+    find_package ( Eigen3 CONFIG REQUIRED )
+endif ( RTA_ENABLE_EIGEN )
 
 if (RTA_CENTOS7_CERES_HACK)
     find_package ( Ceres MODULE REQUIRED )

--- a/src/rawtoaces_core/CMakeLists.txt
+++ b/src/rawtoaces_core/CMakeLists.txt
@@ -25,11 +25,14 @@ add_library( ${RAWTOACES_CORE_LIB} ${DO_SHARED}
 
 target_link_libraries(
     ${RAWTOACES_CORE_LIB}
-    PUBLIC
-        Eigen3::Eigen
     PRIVATE
         nlohmann_json::nlohmann_json
 )
+
+if ( RTA_ENABLE_EIGEN )
+    target_link_libraries( ${RAWTOACES_CORE_LIB} PUBLIC Eigen3::Eigen )
+    target_compile_definitions(${RAWTOACES_CORE_LIB} PRIVATE RTA_ENABLE_EIGEN=1 )
+endif ( RTA_ENABLE_EIGEN )
 
 if ( ${Ceres_VERSION_MAJOR} GREATER 1 )
     target_link_libraries( ${RAWTOACES_CORE_LIB} PUBLIC Ceres::ceres )

--- a/src/rawtoaces_core/core_math.cpp
+++ b/src/rawtoaces_core/core_math.cpp
@@ -4,9 +4,12 @@
 #include "core_math.h"
 #include "define.h"
 
-#if RTA_HAS_EIGEN
+#if defined( RTA_ENABLE_EIGEN ) && RTA_ENABLE_EIGEN
 #    include <Eigen/Core>
-#endif // RTA_HAS_EIGEN
+#    define RTA_HAS_EIGEN 1
+#else
+#    define RTA_HAS_EIGEN 0
+#endif
 
 #include <ceres/ceres.h>
 
@@ -19,6 +22,11 @@ namespace math
 
 // Enabled by default
 bool use_eigen = RTA_HAS_EIGEN;
+
+bool has_eigen()
+{
+    return RTA_HAS_EIGEN;
+}
 
 void check_eigen()
 {

--- a/src/rawtoaces_core/core_math.cpp
+++ b/src/rawtoaces_core/core_math.cpp
@@ -4,7 +4,10 @@
 #include "core_math.h"
 #include "define.h"
 
-#include <Eigen/Core>
+#if RTA_HAS_EIGEN
+#    include <Eigen/Core>
+#endif // RTA_HAS_EIGEN
+
 #include <ceres/ceres.h>
 
 namespace rta
@@ -13,6 +16,29 @@ namespace core
 {
 namespace math
 {
+
+// Enabled by default
+bool use_eigen = RTA_HAS_EIGEN;
+
+void check_eigen()
+{
+#if !RTA_HAS_EIGEN
+    if ( use_eigen )
+    {
+        static bool reported = false;
+        if ( !reported )
+        {
+            std::cerr << "The library was built without Eigen support. "
+                      << "The built-in linear algebra implementation "
+                      << "will be used instead. " << std::endl;
+            reported = true;
+        }
+        use_eigen = false;
+    }
+#endif // !RTA_HAS_EIGEN
+}
+
+#if RTA_HAS_EIGEN
 
 /// Create eigen vector from std::vector
 template <typename T>
@@ -84,6 +110,8 @@ mat_to_std( const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> &mat )
     return result;
 }
 
+#endif // RTA_HAS_EIGEN
+
 bool inverse(
     const std::vector<std::vector<double>> &src_mat,
     std::vector<std::vector<double>>       &dst_mat )
@@ -96,12 +124,70 @@ bool inverse(
     if ( rows != cols )
         return false;
 
-    auto m = mat_from_std( src_mat );
-    if ( std::fabs( m.determinant() ) < 1e-9 )
-        return false;
+#if RTA_HAS_EIGEN
+    if ( use_eigen )
+    {
+        auto m = mat_from_std( src_mat );
+        if ( std::fabs( m.determinant() ) < 1e-9 )
+            return false;
 
-    m       = m.inverse();
-    dst_mat = mat_to_std( m );
+        m       = m.inverse();
+        dst_mat = mat_to_std( m );
+    }
+    else
+#endif // RTA_HAS_EIGEN
+    {
+
+        check_eigen();
+
+        // Currently only supporting 3x3 matrices.
+        if ( rows != 3 )
+            return false;
+
+        double a = src_mat[0][0];
+        double b = src_mat[0][1];
+        double c = src_mat[0][2];
+        double d = src_mat[1][0];
+        double e = src_mat[1][1];
+        double f = src_mat[1][2];
+        double g = src_mat[2][0];
+        double h = src_mat[2][1];
+        double i = src_mat[2][2];
+
+        double A = e * i - f * h;
+        double B = f * g - d * i;
+        double C = d * h - e * g;
+
+        double determinant = A * a + B * b + C * c;
+        if ( std::fabs( determinant ) < 1e-9 )
+            return false;
+
+        double scale = 1.0 / determinant;
+
+        double D = c * h - b * i;
+        double E = a * i - c * g;
+        double F = b * g - a * h;
+        double G = b * f - c * e;
+        double H = c * d - a * f;
+        double I = a * e - b * d;
+
+        dst_mat.resize( 3 );
+
+        dst_mat[0].resize( 3 );
+        dst_mat[0][0] = A * scale;
+        dst_mat[0][1] = D * scale;
+        dst_mat[0][2] = G * scale;
+
+        dst_mat[1].resize( 3 );
+        dst_mat[1][0] = B * scale;
+        dst_mat[1][1] = E * scale;
+        dst_mat[1][2] = H * scale;
+
+        dst_mat[2].resize( 3 );
+        dst_mat[2][0] = C * scale;
+        dst_mat[2][1] = F * scale;
+        dst_mat[2][2] = I * scale;
+    }
 
     return true;
 }
@@ -109,11 +195,34 @@ bool inverse(
 std::vector<std::vector<double>>
 transposed( const std::vector<std::vector<double>> &src_mat )
 {
-    assert( src_mat.size() != 0 && src_mat[0].size() != 0 );
+    size_t rows = src_mat.size();
+    assert( rows > 0 );
 
-    auto m = mat_from_std( src_mat );
-    m.transposeInPlace();
-    auto result = mat_to_std( m );
+    size_t cols = src_mat[0].size();
+    assert( cols > 0 );
+
+    std::vector<std::vector<double>> result;
+
+#if RTA_HAS_EIGEN
+    if ( use_eigen )
+    {
+        auto m = mat_from_std( src_mat );
+        m.transposeInPlace();
+        result = mat_to_std( m );
+    }
+    else
+#endif // RTA_HAS_EIGEN
+    {
+        check_eigen();
+
+        result.resize( cols );
+        for ( size_t i = 0; i < cols; i++ )
+        {
+            result[i].resize( rows );
+            for ( size_t j = 0; j < rows; j++ )
+                result[i][j] = src_mat[j][i];
+        }
+    }
 
     return result;
 }
@@ -123,13 +232,52 @@ std::vector<std::vector<T>> product(
     const std::vector<std::vector<T>> &vct1,
     const std::vector<std::vector<T>> &vct2 )
 {
-    assert( vct1.size() != 0 && vct2.size() != 0 );
+    size_t rows1 = vct1.size();
+    assert( rows1 > 0 );
 
-    auto m1 = mat_from_std( vct1 );
-    auto m2 = mat_from_std( vct2 );
+    size_t cols1 = vct1[0].size();
+    assert( rows1 > 0 );
 
-    Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> m3     = m1 * m2;
-    auto                                             result = mat_to_std( m3 );
+    size_t rows2 [[maybe_unused]] = vct2.size();
+    assert( rows2 > 0 );
+
+    size_t cols2 = vct2[0].size();
+    assert( cols2 > 0 );
+
+    assert( cols1 == rows2 );
+
+    std::vector<std::vector<T>> result;
+
+#if RTA_HAS_EIGEN
+    if ( use_eigen )
+    {
+        auto m1 = mat_from_std( vct1 );
+        auto m2 = mat_from_std( vct2 );
+
+        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> m3 = m1 * m2;
+
+        result = mat_to_std( m3 );
+    }
+    else
+#endif // RTA_HAS_EIGEN
+    {
+        check_eigen();
+
+        result.resize( rows1 );
+
+        for ( size_t i = 0; i < rows1; i++ )
+        {
+            result[i].resize( cols2 );
+
+            for ( size_t j = 0; j < cols2; j++ )
+            {
+                result[i][j] = T( 0.0 );
+
+                for ( size_t k = 0; k < cols1; k++ )
+                    result[i][j] += vct1[i][k] * vct2[k][j];
+            }
+        }
+    }
 
     return result;
 }
@@ -138,13 +286,44 @@ template <typename T>
 std::vector<T>
 product( const std::vector<std::vector<T>> &vct1, const std::vector<T> &vct2 )
 {
-    assert( vct1.size() != 0 && ( vct1[0] ).size() == vct2.size() );
+    size_t rows1 = vct1.size();
+    assert( rows1 > 0 );
 
-    auto m1 = mat_from_std( vct1 );
-    auto m2 = vec_from_std( vct2 );
+    size_t cols1 = vct1[0].size();
+    assert( rows1 > 0 );
 
-    Eigen::Matrix<T, Eigen::Dynamic, 1> m3     = m1 * m2;
-    auto                                result = vec_to_std( m3 );
+    size_t rows2 [[maybe_unused]] = vct2.size();
+    assert( rows2 > 0 );
+
+    assert( cols1 == rows2 );
+
+    std::vector<T> result;
+
+#if RTA_HAS_EIGEN
+    if ( use_eigen )
+    {
+        auto m1 = mat_from_std( vct1 );
+        auto m2 = vec_from_std( vct2 );
+
+        Eigen::Matrix<T, Eigen::Dynamic, 1> m3 = m1 * m2;
+
+        result = vec_to_std( m3 );
+    }
+    else
+#endif // RTA_HAS_EIGEN
+    {
+        check_eigen();
+
+        result.resize( rows1 );
+
+        for ( size_t i = 0; i < rows1; i++ )
+        {
+            result[i] = T( 0.0 );
+
+            for ( size_t j = 0; j < cols1; j++ )
+                result[i] += vct1[i][j] * vct2[j];
+        }
+    }
 
     return result;
 }
@@ -255,10 +434,10 @@ std::vector<std::vector<T>> XYZ_to_LAB( const std::vector<std::vector<T>> &XYZ )
         for ( size_t j = 0; j < 3; j++ )
         {
             tmpXYZ[i][j] = XYZ[i][j] / ACES_white_point_XYZ[j];
-            if ( tmpXYZ[i][j] > T( e ) )
+            if ( tmpXYZ[i][j] > T( k_e ) )
                 tmpXYZ[i][j] = ceres::pow( tmpXYZ[i][j], T( 1.0 / 3.0 ) );
             else
-                tmpXYZ[i][j] = T( k ) * tmpXYZ[i][j] + add;
+                tmpXYZ[i][j] = T( k_k ) * tmpXYZ[i][j] + add;
         }
 
     std::vector<std::vector<T>> outCalcLab( XYZ.size(), std::vector<T>( 3 ) );

--- a/src/rawtoaces_core/core_math.h
+++ b/src/rawtoaces_core/core_math.h
@@ -5,12 +5,6 @@
 
 #include <vector>
 
-#if defined( RTA_ENABLE_EIGEN ) && RTA_ENABLE_EIGEN
-#    define RTA_HAS_EIGEN 1
-#else
-#    define RTA_HAS_EIGEN 0
-#endif
-
 namespace rta
 {
 namespace core
@@ -19,6 +13,8 @@ namespace math
 {
 
 extern bool use_eigen;
+
+bool has_eigen();
 
 bool inverse(
     const std::vector<std::vector<double>> &src_mat,

--- a/src/rawtoaces_core/core_math.h
+++ b/src/rawtoaces_core/core_math.h
@@ -5,12 +5,20 @@
 
 #include <vector>
 
+#if defined( RTA_ENABLE_EIGEN ) && RTA_ENABLE_EIGEN
+#    define RTA_HAS_EIGEN 1
+#else
+#    define RTA_HAS_EIGEN 0
+#endif
+
 namespace rta
 {
 namespace core
 {
 namespace math
 {
+
+extern bool use_eigen;
 
 bool inverse(
     const std::vector<std::vector<double>> &src_mat,

--- a/src/rawtoaces_core/define.h
+++ b/src/rawtoaces_core/define.h
@@ -43,11 +43,11 @@ namespace rta
 namespace core
 {
 
-const double pi = 3.1416;
+const double k_pi = 3.1416;
 // 216.0/24389.0
-const double e = 0.008856451679;
+const double k_e = 0.008856451679;
 // (24389.0/27.0)/116.0
-const double k = 7.787037037037;
+const double k_k = 7.787037037037;
 
 // Planck's constant ([J*s] Joule-seconds)
 const double plancks_constant = 6.626176 * 1e-34;

--- a/src/rawtoaces_core/rawtoaces_core.cpp
+++ b/src/rawtoaces_core/rawtoaces_core.cpp
@@ -107,7 +107,7 @@ void calculate_blackbody_SPD( const int &kelvin, Spectrum &spectrum )
         double c2     = ( plancks_constant * light_speed ) /
                     ( boltzmann_constant * lambda * kelvin );
         spectrum.values.push_back(
-            c1 * pi / ( std::pow( lambda, 5 ) * ( std::exp( c2 ) - 1 ) ) );
+            c1 * k_pi / ( std::pow( lambda, 5 ) * ( std::exp( c2 ) - 1 ) ) );
     }
 }
 

--- a/tests/testMath.cpp
+++ b/tests/testMath.cpp
@@ -618,7 +618,8 @@ void test_GetCalcXYZt()
 
 int main( int, char ** )
 {
-    for ( size_t use_eigen = 0; use_eigen < RTA_HAS_EIGEN + 1; use_eigen++ )
+    size_t steps = rta::core::math::has_eigen() ? 2 : 1;
+    for ( size_t use_eigen = 0; use_eigen < steps; use_eigen++ )
     {
         rta::core::math::use_eigen = use_eigen;
 

--- a/tests/testMath.cpp
+++ b/tests/testMath.cpp
@@ -20,8 +20,8 @@ void test_inverse_failure()
     // Empty row
     OIIO_CHECK_ASSERT( !rta::core::math::inverse( { {}, {} }, result ) );
     // Non-invertible
-    OIIO_CHECK_ASSERT(
-        !rta::core::math::inverse( { { 1.0, 2.0 }, { 1.0, 2.0 } }, result ) );
+    OIIO_CHECK_ASSERT( !rta::core::math::inverse(
+        { { 1.0, 2.0, 3.0 }, { 1.0, 2.0, 3.0 }, { 1.0, 2.0, 3.0 } }, result ) );
 }
 
 void test_inverse_success()
@@ -46,7 +46,7 @@ void test_inverse_success()
     }
 }
 
-void test_TransposeVec()
+void test_transpose()
 {
     double M[6][3] = {
         { 1.0, 0.0, 0.0 }, { 0.0, 2.0, 0.0 }, { 0.0, 0.0, 3.0 },
@@ -618,18 +618,23 @@ void test_GetCalcXYZt()
 
 int main( int, char ** )
 {
-    test_inverse_failure();
-    test_inverse_success();
-    test_TransposeVec();
-    test_mat_mat_mult();
-    test_mat_vec_mult();
-    testIDT_XytoXYZ();
-    testIDT_Uvtoxy();
-    testIDT_UvtoXYZ();
-    testIDT_XYZTouv();
-    testIDT_GetCAT();
-    test_XYZtoLAB();
-    test_GetCalcXYZt();
+    for ( size_t use_eigen = 0; use_eigen < RTA_HAS_EIGEN + 1; use_eigen++ )
+    {
+        rta::core::math::use_eigen = use_eigen;
+
+        test_inverse_failure();
+        test_inverse_success();
+        test_transpose();
+        test_mat_mat_mult();
+        test_mat_vec_mult();
+        testIDT_XytoXYZ();
+        testIDT_Uvtoxy();
+        testIDT_UvtoXYZ();
+        testIDT_XYZTouv();
+        testIDT_GetCAT();
+        test_XYZtoLAB();
+        test_GetCalcXYZt();
+    }
 
     return unit_test_failures;
 }


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Makes the dependency on Eigen optional via the `RTA_ENABLE _EIGEN` cmake option.
Introduces the `rta::core::math::use_eigen` flag to switch between the built-in and Eigen math. The flag is intended for testing purposes only, we do not have any plans to make it public at this stage.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
