### PR TITLE
[refactor] make ceres optional

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -52,6 +52,10 @@ jobs:
 
       - name: Dependencies
         shell: bash
+        env:
+          RTA_ENABLE_LENSFUN: 'ON'
+          RTA_ENABLE_EIGEN: 'ON'
+          RTA_ENABLE_CERES: 'ON'
         run: |
           bash build_scripts/install_deps_ubuntu.bash
           

--- a/.github/workflows/build-steps.yml
+++ b/.github/workflows/build-steps.yml
@@ -36,6 +36,9 @@ on:
       enable_eigen:
         type: string
         default: 'ON'
+      enable_ceres:
+        type: string
+        default: 'ON'
       vfxyear:
         type: number
         default: 0
@@ -80,8 +83,12 @@ jobs:
             vcpkg-binary-cache-${{ runner.os }}-${{ hashFiles('build_scripts/vcpkg.json') }}
           restore-keys: |
             vcpkg-binary-cache-${{ runner.os }}-
-            
+
       - name: Dependencies
+        env:
+          RTA_ENABLE_LENSFUN: '${{inputs.enable_lensfun}}'
+          RTA_ENABLE_EIGEN: '${{inputs.enable_eigen}}'
+          RTA_ENABLE_CERES: '${{inputs.enable_ceres}}'
         shell: bash
         run: |
           bash build_scripts/${{ inputs.install_deps }}.bash
@@ -98,6 +105,7 @@ jobs:
           -D ENABLE_SHARED="${{ inputs.build_shared_libs }}"
           -D RTA_ENABLE_LENSFUN="${{ inputs.enable_lensfun }}"
           -D RTA_ENABLE_EIGEN="${{ inputs.enable_eigen }}"
+          -D RTA_ENABLE_CERES="${{ inputs.enable_ceres }}"
           -D RTA_SANITISER_MODE="${{ inputs.sanitiser_mode }}"
           -D RTA_PYTHON_VERSION="${{ inputs.python_version }}"
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,10 @@ jobs:
       install_deps: install_deps_${{ matrix.os }}
       toolchain_file: ${{ matrix.toolchain_file }}
       build_shared_libs: ${{ matrix.build_shared_libs || 'ON' }}
-      workflow_name: ${{matrix.options[0]}}
-      enable_eigen: ${{ matrix.options[1] }}
-      enable_lensfun: ${{ matrix.options[2] }}
+      workflow_name:  ${{ matrix.options[0] }}
+      enable_eigen:   ${{ matrix.options[1] }}
+      enable_ceres:   ${{ matrix.options[2] }}
+      enable_lensfun: ${{ matrix.options[3] }}
       cxx_standard: 17
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
@@ -75,10 +76,11 @@ jobs:
       matrix:
         os: [ macos, ubuntu, windows ]
         options: [
-          # [ name, enable_eigen, enable_lensfun]
-          ["minimal", OFF, OFF],
-          ["eigen",   ON,  OFF],
-          ["full",    ON,  ON ]
+          # [ name, enable_eigen, enable_ceres, enable_lensfun]
+          ["minimal", 'OFF', 'OFF', 'OFF'],
+          ["eigen",   'ON',  'OFF', 'OFF'],
+          ["ceres",   'OFF', 'ON',  'OFF'],
+          ["full",    'ON',  'ON',  'ON' ]
         ]
         include:
           - os: windows

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,10 @@ jobs:
     
     - name: Install OS dependencies
       shell: bash
+      env:
+        RTA_ENABLE_LENSFUN: 'ON'
+        RTA_ENABLE_EIGEN: 'ON'
+        RTA_ENABLE_CERES: 'ON'
       run: |
         bash build_scripts/install_deps_macos.bash
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,12 @@ endif ()
 ##   Install RAWTOACES.pc
 
 if ( PKG_CONFIG_FOUND )
+  if ( RTA_ENABLE_CERES )
+    set ( RTA_PC_CERES_LIB "-lCeres" )
+  else ()
+    set ( RTA_PC_CERES_LIB "" )
+  endif ()
+
   configure_file(config/RAWTOACES.pc.in "${PROJECT_BINARY_DIR}/RAWTOACES.pc" @ONLY)
   install( FILES "${PROJECT_BINARY_DIR}/RAWTOACES.pc" DESTINATION lib/pkgconfig COMPONENT dev )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ option( RTA_INSTALL_DATABASE "Download and install the spectral measurements dat
 option( ENABLE_COVERAGE "Enable code coverage reporting" OFF )
 option( RTA_ENABLE_LENSFUN "Use lensfun for lens correction" ON )
 option( RTA_ENABLE_EIGEN "Use Eigen for linear algebra" ON )
+option( RTA_ENABLE_CERES "Use Ceres Solver for matrix calculation" ON )
 set ( RTA_SANITISER_MODE "none" CACHE STRING "Dynamic analysis sanitiser mode ('none', 'address', 'memory', or 'thread')" )
 set ( RTA_PYTHON_VERSION ""  CACHE STRING "Python version to use" )
 

--- a/README.md
+++ b/README.md
@@ -57,12 +57,11 @@ To build `rawtoaces` you would need to satisfy these dependencies:
 | `nanobind`       | `2.2.0`    | nanobind is a small binding library that exposes C++ types in Python and vice versa. | [nanobind installation](https://nanobind.readthedocs.io/en/latest/installing.html) |
 | `lensfun`        | `0.3.2`    | Lensfun itself is a library for correcting several lens artefacts and a database for storing lens profiles. | [lensfun installation](https://lensfun.github.io/development/) |
 
-.. note::
-
-   There is an experimental mode allowing to build rawtoaces without requiring Eigen and/or Ceres. In order to do so, please provide these
-   parameters to cmake: `-D RTA_ENABLE_EIGEN=OFF -D RTA_ENABLE_CERES=OFF`. If both dependencies are disabled, there is no need to install
-   Eigen and Ceres. Note that Eigen is a transient dependency of Ceres, so if Eigen is disabled in rawtoaces, but Ceres isn't, you still
-   need to install Eigen.
+> [!NOTE] 
+> There is an experimental mode allowing to build rawtoaces without requiring Eigen and/or Ceres. In order to do so, please provide these
+> parameters to cmake: `-D RTA_ENABLE_EIGEN=OFF -D RTA_ENABLE_CERES=OFF`. If both dependencies are disabled, there is no need to install
+> Eigen and Ceres. Note that Eigen is a transient dependency of Ceres, so if Eigen is disabled in rawtoaces, but Ceres isn't, you still
+> need to install Eigen.
 
 ### MacOS
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,18 @@ To build `rawtoaces` you would need to satisfy these dependencies:
 | -------          | -----------| -------- | -------------------------------- |
 | `cmake`          | `3.12`     | | [CMake download](https://cmake.org/download/)|
 | `ceres`          | `1.12.0`   | Ceres Solver is an open source library for solving Non-linear Least Squares problems with bounds constraints and unconstrained optimization problems. It processes non-linear regression for rawtoaces.  | [Ceres Solver installation](http://ceres-solver.org/installation.html)|
+| `eigen`          | `3.3.7`    | Eigen is an open source library for solving linear algebra problems. | [Eigen installation](https://libeigen.gitlab.io/#download)|
 | `OpenImageIO`    | `3.0`      | OpenImageIO is an open source library providing vast functionality for image processing. rawtoaces relies on OpenImageIO for reading raw files, saving AcesContainer files, and also all pixel operations.  | [OpenImageIO installation](https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/INSTALL.md) |
 | `nlohmann-json`  | `3.6`      | nlohmann-json is a simple header-only library for parsing JSON files. | [nlohmann-json integration](https://github.com/nlohmann/json#integration) |
 | `nanobind`       | `2.2.0`    | nanobind is a small binding library that exposes C++ types in Python and vice versa. | [nanobind installation](https://nanobind.readthedocs.io/en/latest/installing.html) |
 | `lensfun`        | `0.3.2`    | Lensfun itself is a library for correcting several lens artefacts and a database for storing lens profiles. | [lensfun installation](https://lensfun.github.io/development/) |
+
+.. note::
+
+   There is an experimental mode allowing to build rawtoaces without requiring Eigen and/or Ceres. In order to do so, please provide these
+   parameters to cmake: `-D RTA_ENABLE_EIGEN=OFF -D RTA_ENABLE_CERES=OFF`. If both dependencies are disabled, there is no need to install
+   Eigen and Ceres. Note that Eigen is a transient dependency of Ceres, so if Eigen is disabled in rawtoaces, but Ceres isn't, you still
+   need to install Eigen.
 
 ### MacOS
 

--- a/build_scripts/install_deps_macos.bash
+++ b/build_scripts/install_deps_macos.bash
@@ -11,17 +11,17 @@ brew install \
     robin-map \
     exiftool
 
-if [ "$RTA_ENABLE_EIGEN" == "ON" ];
+if [ "$RTA_ENABLE_EIGEN" != "OFF" ];
 then
     brew install eigen
 fi
 
-if [ "$RTA_ENABLE_CERES" == "ON" ];
+if [ "$RTA_ENABLE_CERES" != "OFF" ];
 then
     brew install ceres-solver
 fi
 
-if [ "$RTA_ENABLE_LENSFUN" == "ON" ];
+if [ "$RTA_ENABLE_LENSFUN" != "OFF" ];
 then
     brew install lensfun
 fi

--- a/build_scripts/install_deps_macos.bash
+++ b/build_scripts/install_deps_macos.bash
@@ -5,12 +5,26 @@ set -ex
 brew update
 
 brew install \
-    ceres-solver \
     nlohmann-json \
     openimageio \
     nanobind \
     robin-map \
-    exiftool \
-    lensfun
+    exiftool
+
+if [ "$RTA_ENABLE_EIGEN" == "ON" ];
+then
+    brew install eigen
+fi
+
+if [ "$RTA_ENABLE_CERES" == "ON" ];
+then
+    brew install ceres-solver
+fi
+
+if [ "$RTA_ENABLE_LENSFUN" == "ON" ];
+then
+    brew install lensfun
+fi
+
 
 python3 -m pip install --break-system-packages pytest

--- a/build_scripts/install_deps_ubuntu.bash
+++ b/build_scripts/install_deps_ubuntu.bash
@@ -5,13 +5,30 @@ set -ex
 time sudo apt-get update
 
 time sudo apt-get -q -f install -y \
-    libceres-dev \
     nlohmann-json3-dev \
     libopencv-dev \
     openimageio-tools libopenimageio-dev \
     exiftool \
-    liblensfun-dev \
-    liblensfun-data-v1
+
+if [ "$RTA_ENABLE_EIGEN" == "ON" ];
+then
+    time sudo apt-get -q -f install -y \
+        libeigen3-dev
+fi
+
+if [ "$RTA_ENABLE_CERES" == "ON" ];
+then
+    time sudo apt-get -q -f install -y \
+        libceres-dev
+fi
+
+if [ "$RTA_ENABLE_LENSFUN" == "ON" ];
+then
+    time sudo apt-get -q -f install -y \
+        liblensfun-dev \
+        liblensfun-data-v1
+fi
+
 
 # Nanobind in apt is still v1.9, we need at least v2.2.
 pip3 install pytest nanobind

--- a/build_scripts/install_deps_ubuntu.bash
+++ b/build_scripts/install_deps_ubuntu.bash
@@ -10,19 +10,19 @@ time sudo apt-get -q -f install -y \
     openimageio-tools libopenimageio-dev \
     exiftool \
 
-if [ "$RTA_ENABLE_EIGEN" == "ON" ];
+if [ "$RTA_ENABLE_EIGEN" != "OFF" ];
 then
     time sudo apt-get -q -f install -y \
         libeigen3-dev
 fi
 
-if [ "$RTA_ENABLE_CERES" == "ON" ];
+if [ "$RTA_ENABLE_CERES" != "OFF" ];
 then
     time sudo apt-get -q -f install -y \
         libceres-dev
 fi
 
-if [ "$RTA_ENABLE_LENSFUN" == "ON" ];
+if [ "$RTA_ENABLE_LENSFUN" != "OFF" ];
 then
     time sudo apt-get -q -f install -y \
         liblensfun-dev \

--- a/build_scripts/install_deps_windows.bash
+++ b/build_scripts/install_deps_windows.bash
@@ -9,10 +9,23 @@ export VCPKG_BINARY_SOURCES="clear;files,C:/vcpkg/binary-cache,readwrite"
 # Baseline is pinned in vcpkg.json. The latest hash can be found with:
 #   git ls-remote https://github.com/microsoft/vcpkg HEAD | cut -f1
 
+FEATURES=""
+
+if [ "$RTA_ENABLE_LENSFUN" == "ON" ]; then
+    FEATURES="$FEATURES --x-feature=lensfun"
+fi
+
+if [ "$RTA_ENABLE_CERES" == "ON" ]; then
+    FEATURES="$FEATURES --x-feature=ceres"
+elif  [ "$RTA_ENABLE_EIGEN" == "ON" ]; then
+    FEATURES="$FEATURES --x-feature=eigen"
+fi
+
 # Install dependencies - vcpkg will automatically use binary cache if available
 vcpkg install \
     --x-install-root="C:/vcpkg/installed" \
-    --x-manifest-root="./build_scripts"
+    --x-manifest-root="./build_scripts" \
+    $FEATURES
 
 # Install pip and pytest to the vcpkg Python
 # Since vcpkg Python doesn't include pip, install it first using ensurepip

--- a/build_scripts/install_deps_windows.bash
+++ b/build_scripts/install_deps_windows.bash
@@ -11,13 +11,13 @@ export VCPKG_BINARY_SOURCES="clear;files,C:/vcpkg/binary-cache,readwrite"
 
 FEATURES=""
 
-if [ "$RTA_ENABLE_LENSFUN" == "ON" ]; then
+if [ "$RTA_ENABLE_LENSFUN" != "OFF" ]; then
     FEATURES="$FEATURES --x-feature=lensfun"
 fi
 
-if [ "$RTA_ENABLE_CERES" == "ON" ]; then
+if [ "$RTA_ENABLE_CERES" != "OFF" ]; then
     FEATURES="$FEATURES --x-feature=ceres"
-elif  [ "$RTA_ENABLE_EIGEN" == "ON" ]; then
+elif  [ "$RTA_ENABLE_EIGEN" != "OFF" ]; then
     FEATURES="$FEATURES --x-feature=eigen"
 fi
 

--- a/build_scripts/vcpkg.json
+++ b/build_scripts/vcpkg.json
@@ -2,12 +2,24 @@
 {
     "builtin-baseline": "2b6a882f61eaa764ec3cf816e2265fe804a44cd0",
     "dependencies": [
-        "ceres",
         "nlohmann-json",
         { "name": "openimageio", "features": [ "libraw" ] },
-        "nanobind",
-        "lensfun"
+        "nanobind"
     ],
+    "features": {
+        "lensfun": {
+            "description": "use lensfun for lens correction",
+            "dependencies": ["lensfun"]
+        },
+        "eigen": {
+            "description": "use eigen for linear algebra",
+            "dependencies": ["eigen3"]
+        },
+        "ceres": {
+            "description": "use ceres in the non-linear solver",
+            "dependencies": ["ceres"]
+        }
+    },
     "overrides": [
         { "name": "eigen3", "version": "3.4.0" }
     ]

--- a/config/RAWTOACES.pc.in
+++ b/config/RAWTOACES.pc.in
@@ -7,5 +7,5 @@ RAWTOACES_includedir=@INSTALL_INCLUDE_DIR@/rawtoaces
 Name: RAWTOACES
 Description: RAWTOACES raw image to ACES
 Version: @RAWTOACES_VERSION@
-Libs: -L${libdir} -lCeres
+Libs: -L${libdir} @RTA_PC_CERES_LIB@
 Cflags: -I${RAWTOACES_includedir}

--- a/config/RAWTOACESConfig.cmake.in
+++ b/config/RAWTOACESConfig.cmake.in
@@ -4,10 +4,7 @@ set(rawtoaces_VERSION "@RAWTOACES_VERSION@")
 
 @PACKAGE_INIT@
 
-include(${CMAKE_CURRENT_LIST_DIR}/RAWTOACESTargets.cmake)
-
 include(CMakeFindDependencyMacro)
-    
 find_dependency ( OpenImageIO )
     
 if ( NOT @ENABLE_SHARED@ )
@@ -17,7 +14,11 @@ if ( NOT @ENABLE_SHARED@ )
         find_dependency ( Eigen3 )
     endif ()
     
-    find_dependency ( Ceres )
+    if ( @RTA_ENABLE_CERES@ )
+        find_dependency ( Ceres )
+    endif ()
 endif ( NOT @ENABLE_SHARED@ )
+
+include(${CMAKE_CURRENT_LIST_DIR}/RAWTOACESTargets.cmake)
 
 check_required_components(rawtoaces)

--- a/configure.cmake
+++ b/configure.cmake
@@ -9,7 +9,9 @@ if ( RTA_ENABLE_EIGEN )
     find_package ( Eigen3 CONFIG REQUIRED )
 endif ( RTA_ENABLE_EIGEN )
 
-find_package ( Ceres CONFIG REQUIRED )
+if ( RTA_ENABLE_CERES )
+    find_package ( Ceres CONFIG REQUIRED )
+endif ()
 
 if ( RTA_ENABLE_LENSFUN )
     find_package ( PkgConfig REQUIRED )

--- a/src/rawtoaces_core/CMakeLists.txt
+++ b/src/rawtoaces_core/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library( ${RAWTOACES_CORE_LIB} ${DO_SHARED}
     rawtoaces_core_priv.h
     define.h
     core_math.h
+    core_math_priv.h
 )
 
 target_link_libraries(
@@ -34,12 +35,16 @@ if ( RTA_ENABLE_EIGEN )
     target_compile_definitions(${RAWTOACES_CORE_LIB} PRIVATE RTA_ENABLE_EIGEN=1 )
 endif ( RTA_ENABLE_EIGEN )
 
-if ( ${Ceres_VERSION_MAJOR} GREATER 1 )
-    target_link_libraries( ${RAWTOACES_CORE_LIB} PRIVATE Ceres::ceres )
-else ()
-    target_include_directories(${RAWTOACES_CORE_LIB} PRIVATE ${CERES_INCLUDE_DIRS})
-    target_link_libraries(${RAWTOACES_CORE_LIB} PRIVATE ${CERES_LIBRARIES})
-endif ()
+if ( RTA_ENABLE_CERES )
+    if ( ${Ceres_VERSION_MAJOR} GREATER 1 )
+        target_link_libraries( ${RAWTOACES_CORE_LIB} PRIVATE Ceres::ceres )
+    else ()
+        target_include_directories(${RAWTOACES_CORE_LIB} PRIVATE ${CERES_INCLUDE_DIRS})
+        target_link_libraries(${RAWTOACES_CORE_LIB} PRIVATE ${CERES_LIBRARIES})
+    endif ()
+
+    target_compile_definitions(${RAWTOACES_CORE_LIB} PRIVATE RTA_ENABLE_CERES=1 )
+endif ( RTA_ENABLE_CERES )
 
 target_include_directories( ${RAWTOACES_CORE_LIB} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>

--- a/src/rawtoaces_core/core_math.cpp
+++ b/src/rawtoaces_core/core_math.cpp
@@ -586,7 +586,10 @@ template <typename T> struct is_same<T, T>
     static const bool value = true;
 };
 
+// (6/29)^3, used in lab_F() and lab_F_prime().
 constexpr double v_6_29__3 = 6.0 * 6.0 * 6.0 / 29.0 / 29.0 / 29.0;
+
+// (29/6)^2, used in lab_F() and lab_F_prime().
 constexpr double v_29_6__2 = 29.0 * 29.0 / 6.0 / 6.0;
 
 // The non-linear perceptual function of the XYZ to LAB conversion.

--- a/src/rawtoaces_core/core_math.cpp
+++ b/src/rawtoaces_core/core_math.cpp
@@ -3,15 +3,24 @@
 
 #include "core_math.h"
 #include "define.h"
+#include <assert.h>
+#include <cmath>
 
 #if defined( RTA_ENABLE_EIGEN ) && RTA_ENABLE_EIGEN
 #    include <Eigen/Core>
+#    include <Eigen/Dense>
+#    include <Eigen/QR>
 #    define RTA_HAS_EIGEN 1
 #else
 #    define RTA_HAS_EIGEN 0
 #endif
 
-#include <ceres/ceres.h>
+#if defined( RTA_ENABLE_CERES ) && RTA_ENABLE_CERES
+#    include <ceres/ceres.h>
+#    define RTA_HAS_CERES 1
+#else
+#    define RTA_HAS_CERES 0
+#endif
 
 namespace rta
 {
@@ -20,12 +29,20 @@ namespace core
 namespace math
 {
 
-// Enabled by default
+// Enabled by default if Eigen is available.
 bool use_eigen = RTA_HAS_EIGEN;
+
+// Enabled by default if Ceres is available.
+bool use_ceres = RTA_HAS_CERES;
 
 bool has_eigen()
 {
     return RTA_HAS_EIGEN;
+}
+
+bool has_ceres()
+{
+    return RTA_HAS_CERES;
 }
 
 void check_eigen()
@@ -44,6 +61,24 @@ void check_eigen()
         use_eigen = false;
     }
 #endif // !RTA_HAS_EIGEN
+}
+
+void check_ceres()
+{
+#if !RTA_HAS_CERES
+    if ( use_ceres )
+    {
+        static bool reported = false;
+        if ( !reported )
+        {
+            std::cerr << "The library was built without Ceres-solver support. "
+                      << "The build-in solver will be used instead."
+                      << std::endl;
+            reported = true;
+        }
+        use_ceres = false;
+    }
+#endif // !RTA_HAS_CERES
 }
 
 #if RTA_HAS_EIGEN
@@ -443,7 +478,18 @@ std::vector<std::vector<T>> XYZ_to_LAB( const std::vector<std::vector<T>> &XYZ )
         {
             tmpXYZ[i][j] = XYZ[i][j] / ACES_white_point_XYZ[j];
             if ( tmpXYZ[i][j] > T( k_e ) )
-                tmpXYZ[i][j] = ceres::pow( tmpXYZ[i][j], T( 1.0 / 3.0 ) );
+            {
+#if RTA_HAS_CERES
+                if ( use_ceres )
+                {
+                    tmpXYZ[i][j] = ceres::pow( tmpXYZ[i][j], T( 1.0 / 3.0 ) );
+                }
+                else
+#endif // RTA_HAS_CERES
+                {
+                    tmpXYZ[i][j] = std::pow( tmpXYZ[i][j], T( 1.0 / 3.0 ) );
+                }
+            }
             else
                 tmpXYZ[i][j] = T( k_k ) * tmpXYZ[i][j] + add;
         }
@@ -490,6 +536,196 @@ getCalcXYZt( const std::vector<std::vector<T>> &RGB, const T beta_params[6] )
     return calc_XYZ;
 }
 
+// Change the base type of a vector of numbers.
+template <typename T_dst, typename T_src>
+std::vector<T_dst> change_type( const std::vector<T_src> &vec )
+{
+    std::vector<T_dst> result( vec.size() );
+    std::transform(
+        vec.begin(), vec.end(), result.begin(), []( const T_src &v ) {
+            return T_dst( v );
+        } );
+    return result;
+}
+
+// Change the base type of a matrix of numbers.
+template <typename T_dst, typename T_src>
+std::vector<std::vector<T_dst>>
+change_type( const std::vector<std::vector<T_src>> &mat )
+{
+    std::vector<std::vector<T_dst>> result( mat.size() );
+    std::transform(
+        mat.begin(),
+        mat.end(),
+        result.begin(),
+        []( const std::vector<T_src> &v ) { return change_type<T_dst>( v ); } );
+    return result;
+}
+
+// Explicit no-op specialisation when double->double conversion requested.
+template <> std::vector<double> change_type( const std::vector<double> &vec )
+{
+    return vec;
+}
+
+// Explicit no-op specialisation when double->double conversion requested.
+template <>
+std::vector<std::vector<double>>
+change_type( const std::vector<std::vector<double>> &mat )
+{
+    return mat;
+}
+
+template <typename T, typename U> struct is_same
+{
+    static const bool value = false;
+};
+
+template <typename T> struct is_same<T, T>
+{
+    static const bool value = true;
+};
+
+constexpr double v_6_29__3 = 6.0 * 6.0 * 6.0 / 29.0 / 29.0 / 29.0;
+constexpr double v_29_6__2 = 29.0 * 29.0 / 6.0 / 6.0;
+
+// The non-linear perceptual function of the XYZ to LAB conversion.
+template <typename T> T lab_F( T arg )
+{
+    if ( arg > v_6_29__3 )
+    {
+#if RTA_HAS_CERES
+        constexpr bool is_ceres = !is_same<T, double>::value;
+        if constexpr ( is_ceres )
+        {
+            return ceres::pow( arg, T( 1.0 / 3.0 ) );
+        }
+        else
+#endif // RTA_HAS_CERES
+        {
+            return std::pow( arg, T( 1.0 / 3.0 ) );
+        }
+    }
+    else
+        return arg * v_29_6__2 / 3.0 + 4.0 / 29.0;
+}
+
+// The derivative of `lab_F`, see above.
+// (lab_F(arg))' = lab_F'(arg) * arg'
+template <typename T> T lab_F_prime( T arg, T arg_prime )
+{
+    if ( arg > v_6_29__3 )
+    {
+#if RTA_HAS_CERES
+        constexpr bool is_ceres = !is_same<T, double>::value;
+        if constexpr ( is_ceres )
+        {
+            // LCOV_EXCL_START
+            // This code is never executed, as Ceres calculates its own
+            // derivatives. We can not remove this branching
+            // completely, the compiler will complain about this function
+            // called in Ceres mode. Could have put `return 0` here, but having
+            // the correct code looks tidier.
+            return T( 1.0 / 3.0 ) * ceres::pow( arg, -2.0 / 3.0 ) * arg_prime;
+            // LCOV_EXCL_STOP
+        }
+        else
+#endif // RTA_HAS_CERES
+        {
+            return T( 1.0 / 3.0 ) * std::pow( arg, -2.0 / 3.0 ) * arg_prime;
+        }
+    }
+    else
+        return arg_prime * v_29_6__2 / 3.0;
+}
+
+// XYZ to LAB conversion.
+// The input XYZ value must be pre-normalised to the white point.
+template <typename T> void XYZ_to_LAB( const T ( &in )[3], T ( &out )[3] )
+{
+    out[0] = T( 116.0 ) * lab_F( in[1] ) - T( 16.0 );
+    out[1] = T( 500.0 ) * ( lab_F( in[0] ) - lab_F( in[1] ) );
+    out[2] = T( 200.0 ) * ( lab_F( in[1] ) - lab_F( in[2] ) );
+}
+
+// The derivative of the `XYZ_to_LAB` function, see above.
+template <typename T>
+void XYZ_to_LAB_prime(
+    const T ( &arg )[3], const T ( &arg_prime )[3], T ( &out )[3] )
+{
+    out[0] = T( 116.0 ) * lab_F_prime( arg[1], arg_prime[1] );
+    out[1] = T( 500.0 ) * ( lab_F_prime( arg[0], arg_prime[0] ) -
+                            lab_F_prime( arg[1], arg_prime[1] ) );
+    out[2] = T( 200.0 ) * ( lab_F_prime( arg[1], arg_prime[1] ) -
+                            lab_F_prime( arg[2], arg_prime[2] ) );
+}
+
+/// Solve a system of linear equations using Gauss elimination.
+bool solve_linear( std::vector<std::vector<double>> &a, std::vector<double> &b )
+{
+    size_t n = a.size();
+    assert( n > 0 );
+    assert( a[0].size() == n );
+    assert( b.size() == n );
+
+    for ( size_t i = 0; i < n; i++ )
+    {
+        double max_val = a[i][i];
+        size_t pivot   = i;
+
+        for ( size_t j = i; j < n; j++ )
+        {
+            double v = std::abs( a[i][j] );
+            if ( v > max_val )
+            {
+                max_val = v;
+                pivot   = j;
+            }
+        }
+
+        if ( max_val == 0 )
+            return false;
+
+        if ( pivot != i )
+        {
+            std::swap( a[i], a[pivot] );
+            std::swap( b[i], b[pivot] );
+        }
+
+        double scale = 1.0 / a[i][i];
+        for ( size_t k = i + 1; k < n; k++ )
+        {
+            a[i][k] *= scale;
+        }
+        a[i][i] = 1.0;
+        b[i] *= scale;
+
+        for ( size_t j = i + 1; j < n; j++ )
+        {
+            if ( a[j][i] != 0 )
+            {
+                double local_scale = -a[j][i];
+                for ( size_t k = i; k < n; k++ )
+                {
+                    a[j][k] += a[i][k] * local_scale;
+                }
+                b[j] += b[i] * local_scale;
+            }
+        }
+    }
+
+    for ( size_t i = n - 1; i > 0; i-- )
+    {
+        for ( size_t j = 0; j < i; j++ )
+        {
+            double scale = -a[j][i];
+            b[j] += b[i] * scale;
+        }
+    }
+
+    return true;
+}
+
 /// Cost function object for IDT matrix optimization using Ceres solver.
 /// This struct implements the objective function for curve fitting between camera RGB
 /// responses and target XYZ values. It's used to find the optimal 6-parameter IDT
@@ -504,7 +740,10 @@ struct IDTOptimizationCost
     {}
 
     template <typename T>
-    bool operator()( const T *beta_params, T *residuals ) const;
+    bool operator()(
+        const T                     *beta_params,
+        T                           *residuals,
+        std::vector<std::vector<T>> *jacobian = nullptr ) const;
 
     const std::vector<std::vector<double>> _source_RGB;
     const std::vector<std::vector<double>> _target_LAB;
@@ -527,23 +766,119 @@ struct IDTOptimizationCost
 /// @pre _source_RGB must contain camera RGB responses
 /// @pre _target_LAB must contain target LAB values
 template <typename T>
-bool IDTOptimizationCost::operator()( const T *beta_params, T *residuals ) const
+bool IDTOptimizationCost::operator()(
+    const T                     *beta_params,
+    T                           *residuals,
+    std::vector<std::vector<T>> *jacobian ) const
 {
-    std::vector<std::vector<T>> RGB_copy(
-        _source_RGB.size(), std::vector<T>( 3 ) );
-    for ( size_t i = 0; i < _source_RGB.size(); i++ )
-        for ( size_t j = 0; j < 3; j++ )
-            RGB_copy[i][j] = T( _source_RGB[i][j] );
+    size_t n = _source_RGB.size();
+    assert( n > 0 );
 
-    std::vector<std::vector<T>> out_calc_LAB =
-        XYZ_to_LAB( getCalcXYZt( RGB_copy, beta_params ) );
-    for ( size_t i = 0; i < _source_RGB.size(); i++ )
+    std::vector<std::vector<T>> source_rgb =
+        change_type<T, double>( _source_RGB );
+    std::vector<std::vector<T>> target_lab =
+        change_type<T, double>( _target_LAB );
+
+    const T                    *B = beta_params;
+    const T                     T1( 1.0 );
+    std::vector<std::vector<T>> mat_idt_transposed = {
+        { B[0], B[2], B[4] },
+        { B[1], B[3], B[5] },
+        { T1 - B[0] - B[1], T1 - B[2] - B[3], T1 - B[4] - B[5] }
+    };
+
+    std::vector<std::vector<T>> mat_out_to_xyz_transposed(
+        3, std::vector<T>( 3 ) );
+    for ( size_t i = 0; i < 3; i++ )
+    {
         for ( size_t j = 0; j < 3; j++ )
-            residuals[i * 3 + j] = _target_LAB[i][j] - out_calc_LAB[i][j];
+        {
+            mat_out_to_xyz_transposed[i][j] = T( acesrgb_XYZ_3[j][i] );
+        }
+    }
+
+    std::vector<std::vector<T>> rgb_W = { { T1, T1, T1 } };
+
+    std::vector<std::vector<T>> out_rgb =
+        product( source_rgb, mat_idt_transposed );
+    std::vector<std::vector<T>> out_xyz =
+        product( out_rgb, mat_out_to_xyz_transposed );
+    std::vector<std::vector<T>> xyz_W =
+        product( rgb_W, mat_out_to_xyz_transposed );
+
+    for ( size_t i = 0; i < n; i++ )
+    {
+        T xyz1[3] = { out_xyz[i][0], out_xyz[i][1], out_xyz[i][2] };
+
+        for ( size_t j = 0; j < 3; j++ )
+        {
+            xyz1[j] /= xyz_W[0][j];
+        }
+
+        T lab1[3];
+        T lab2[3] = { T( target_lab[i][0] ),
+                      T( target_lab[i][1] ),
+                      T( target_lab[i][2] ) };
+
+        XYZ_to_LAB( xyz1, lab1 );
+
+        residuals[i * 3 + 0] = lab1[0] - lab2[0];
+        residuals[i * 3 + 1] = lab1[1] - lab2[1];
+        residuals[i * 3 + 2] = lab1[2] - lab2[2];
+
+        if ( jacobian != nullptr )
+        {
+            // Partial derivatives of the out_rgb with regards to the IDT
+            // matrix variables (x)
+
+            // Ro = x0*(Rs-Bs) + x1*(Gs-Bs) + Rw*Bs
+            // Go = x2*(Rs-Bs) + x3*(Gs-Bs) + Gw*Bs
+            // Bo = x4*(Rs-Bs) + x5*(Gs-Bs) + Bw*Bs
+
+            // Ro_ = (Rs-Bs) when j == 0, 0 otherwise
+            // Ro_ = (Gs-Bs) when j == 1, 0 otherwise
+            // Go_ = (Rs-Bs) when j == 2, 0 otherwise
+            // Go_ = (Gs-Bs) when j == 3, 0 otherwise
+            // Bo_ = (Rs-Bs) when j == 4, 0 otherwise
+            // Bo_ = (Gs-Bs) when j == 5, 0 otherwise
+
+            T &Rs = source_rgb[i][0];
+            T &Gs = source_rgb[i][1];
+            T &Bs = source_rgb[i][2];
+
+            std::vector<std::vector<T>> out_rgb_ = {
+                { Rs - Bs, T( 0 ), T( 0 ) }, { Gs - Bs, T( 0 ), T( 0 ) },
+                { T( 0 ), Rs - Bs, T( 0 ) }, { T( 0 ), Gs - Bs, T( 0 ) },
+                { T( 0 ), T( 0 ), Rs - Bs }, { T( 0 ), T( 0 ), Gs - Bs },
+            };
+
+            // Partial derivatives of the out_xyz with regards to the IDT
+            // matrix variables (x), which is just the out_to_xyz matrix
+            // applied to out_rgb_.
+            std::vector<std::vector<T>> out_xyz_ =
+                product( out_rgb_, mat_out_to_xyz_transposed );
+
+            for ( size_t j = 0; j < 6; j++ )
+            {
+                T xyz_[3] = { out_xyz_[j][0] / xyz_W[0][0],
+                              out_xyz_[j][1] / xyz_W[0][1],
+                              out_xyz_[j][2] / xyz_W[0][2] };
+
+                T lab_[3];
+                XYZ_to_LAB_prime( xyz1, xyz_, lab_ );
+
+                for ( size_t c = 0; c < 3; c++ )
+                {
+                    ( *jacobian )[i * 3 + c][j] = T( lab_[c] );
+                }
+            }
+        }
+    }
 
     return true;
 }
 
+#if RTA_HAS_CERES
 /// Solve a non-linear optimisation problem by minimising the cost function
 /// provided in `cost_function`.
 ///
@@ -555,10 +890,12 @@ bool IDTOptimizationCost::operator()( const T *beta_params, T *residuals ) const
 /// - 3: Ceres solver full report to stderr
 /// - 4: Additionally enables Ceres minimizer progress to stdout
 /// @return true if optimization succeeded, false otherwise
-inline bool minimise(
+inline bool minimise_ceres(
     IDTOptimizationCost *cost_function,
     std::vector<double> &beta_params,
     size_t               size,
+    double               error_threshold,
+    size_t               max_steps,
     int                  verbosity )
 {
     ceres::Problem problem;
@@ -571,10 +908,10 @@ inline bool minimise(
 
     ceres::Solver::Options options;
     options.linear_solver_type        = ceres::DENSE_QR;
-    options.parameter_tolerance       = 1e-17;
-    options.function_tolerance        = 1e-17;
-    options.min_line_search_step_size = 1e-17;
-    options.max_num_iterations        = 300;
+    options.parameter_tolerance       = error_threshold;
+    options.function_tolerance        = error_threshold;
+    options.min_line_search_step_size = error_threshold;
+    options.max_num_iterations        = (int)max_steps;
 
     if ( verbosity > 3 )
         options.minimizer_progress_to_stdout = true;
@@ -587,10 +924,175 @@ inline bool minimise(
 
     return summary.num_successful_steps > 0;
 }
+#endif // RTA_HAS_CERES
+
+void print_summary(
+    const std::string &status,
+    double             initial_cost,
+    double             final_cost,
+    size_t             steps )
+{
+    std::cerr << std::scientific;
+    std::cerr << "Solver Summary (built-in solver)" << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Cost:" << std::endl;
+    std::cerr << "Initial " << std::right << std::setw( 37 ) << initial_cost
+              << std::endl;
+    std::cerr << "Final   " << std::right << std::setw( 37 ) << final_cost
+              << std::endl;
+    std::cerr << "Change  " << std::right << std::setw( 37 )
+              << initial_cost - final_cost << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Minimizer iterations " << std::right << std::setw( 24 )
+              << steps << std::endl;
+    std::cerr << std::endl;
+    std::cerr << "Termination:     " << status << std::endl;
+    std::cerr << std::endl;
+}
+
+inline bool minimise_builtin(
+    IDTOptimizationCost *cost_function,
+    std::vector<double> &beta_params,
+    size_t               size,
+    double               error_threshold,
+    size_t               max_steps,
+    int                  verbosity )
+{
+    assert( cost_function != nullptr );
+
+    bool        result = true;
+    std::string status;
+
+    size_t step         = 0;
+    double prev_cost    = 0;
+    double initial_cost = 0;
+
+    std::vector<std::vector<double>> jacobian(
+        size, std::vector<double>( 6, 0 ) );
+    std::vector<double> residuals( size, 0 );
+
+    while ( true )
+    {
+        if ( step == max_steps )
+        {
+            status = "NO_CONVERGENCE (Maximum number of iterations reached.)";
+            break;
+        }
+
+        double *B = beta_params.data();
+
+        // The cost function currently always returns true.
+        bool cost_result = ( *cost_function )( B, residuals.data(), &jacobian );
+        assert( cost_result );
+        (void)cost_result;
+
+        double new_cost = 0;
+        for ( auto &i: residuals )
+        {
+            new_cost += i * i;
+        }
+
+        if ( std::isnan( new_cost ) )
+        {
+            result = false;
+            status =
+                "FAILURE "
+                "(Initial residual and Jacobian evaluation failed.)";
+            break;
+        }
+
+        new_cost *= 0.5;
+
+        if ( step == 0 )
+        {
+            prev_cost    = new_cost;
+            initial_cost = new_cost;
+        }
+
+        auto J_t = transposed( jacobian );
+        auto A   = product( J_t, jacobian );
+        auto b   = product( J_t, residuals );
+
+        // Solve A * x = b to find the gradient
+
+#if RTA_HAS_EIGEN
+        if ( use_eigen )
+        {
+            Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> A_mat =
+                mat_from_std( A );
+            Eigen::Matrix<double, Eigen::Dynamic, 1> b_vec = vec_from_std( b );
+            Eigen::Matrix<double, Eigen::Dynamic, 1> x =
+                A_mat.colPivHouseholderQr().solve( b_vec );
+            b = vec_to_std( x );
+        }
+        else
+#endif //RTA_HAS_EIGEN
+        {
+            if ( !solve_linear( A, b ) )
+            {
+                for ( auto &v: b )
+                {
+                    v = 0.0;
+                }
+            }
+        }
+
+        double grad = 0;
+        for ( const auto &v: b )
+        {
+            grad = std::max( grad, std::fabs( v ) );
+        }
+
+        if ( grad < error_threshold )
+        {
+            status = "CONVERGENCE (Gradient tolerance reached.)";
+            break;
+        }
+
+        for ( size_t i = 0; i < 6; i++ )
+        {
+            beta_params[i] -= b[i];
+        }
+
+        if ( verbosity > 3 )
+        {
+            if ( step == 0 )
+            {
+                std::cout << "iter      cost      cost_change" << std::endl;
+            }
+
+            std::cout << std::setw( 4 ) << step << std::setw( 0 ) << " "
+                      << " " << std::right << std::setw( 12 )
+                      << std::setprecision( 6 ) << std::scientific << new_cost
+                      << " " << std::right << std::setw( 11 )
+                      << std::setprecision( 2 ) << std::scientific
+                      << prev_cost - new_cost << std::endl;
+        }
+
+        if ( step > 0 && ( std::abs( prev_cost - new_cost ) <
+                           prev_cost * error_threshold ) )
+        {
+            status = "CONVERGENCE (Function tolerance reached.)";
+            break;
+        }
+        prev_cost = new_cost;
+
+        step++;
+    }
+
+    delete cost_function;
+    if ( verbosity > 2 )
+    {
+        print_summary( status, initial_cost, prev_cost, step );
+    }
+    return result;
+}
 
 bool solve_spectral_transform(
     const std::vector<std::vector<double>> &source_RGB,
     const std::vector<std::vector<double>> &target_XYZ,
+    double                                  error_threshold,
+    size_t                                  max_steps,
     int                                     verbosity,
     std::vector<std::vector<double>>       &out_IDT_matrix )
 {
@@ -599,7 +1101,33 @@ bool solve_spectral_transform(
 
     std::vector<double> beta_params = { 1.0, 0.0, 0.0, 1.0, 0.0, 0.0 };
 
-    if ( minimise( cost_function, beta_params, size, verbosity ) )
+    bool success = false;
+
+#if RTA_HAS_CERES
+    if ( use_ceres )
+    {
+        success = minimise_ceres(
+            cost_function,
+            beta_params,
+            size,
+            error_threshold,
+            max_steps,
+            verbosity );
+    }
+    else
+#endif // RTA_HAS_CERES
+    {
+        check_ceres();
+        success = minimise_builtin(
+            cost_function,
+            beta_params,
+            size,
+            error_threshold,
+            max_steps,
+            verbosity );
+    }
+
+    if ( success )
     {
         out_IDT_matrix.resize( 3 );
         out_IDT_matrix[0].resize( 3 );
@@ -622,6 +1150,16 @@ bool solve_spectral_transform(
     return false;
 }
 
+bool solve_spectral_transform(
+    const std::vector<std::vector<double>> &source_RGB,
+    const std::vector<std::vector<double>> &target_XYZ,
+    int                                     verbosity,
+    std::vector<std::vector<double>>       &out_IDT_matrix )
+{
+    return solve_spectral_transform(
+        source_RGB, target_XYZ, 1e-17, 300, verbosity, out_IDT_matrix );
+}
+
 // Explicit instantiation
 template std::vector<std::vector<double>> product<double>(
     const std::vector<std::vector<double>> &vct1,
@@ -639,6 +1177,15 @@ XYZ_to_LAB( const std::vector<std::vector<double>> &XYZ );
 // Explicit instantiation
 template std::vector<std::vector<double>> getCalcXYZt(
     const std::vector<std::vector<double>> &RGB, const double beta_params[6] );
+
+// Explicit instantiation
+template void XYZ_to_LAB( const double ( &in )[3], double ( &out )[3] );
+
+// Explicit instantiation
+template void XYZ_to_LAB_prime(
+    const double ( &arg )[3],
+    const double ( &arg_prime )[3],
+    double ( &out )[3] );
 
 } // namespace math
 } // namespace core

--- a/src/rawtoaces_core/core_math.cpp
+++ b/src/rawtoaces_core/core_math.cpp
@@ -678,7 +678,7 @@ bool solve_linear( std::vector<std::vector<double>> &a, std::vector<double> &b )
 
         for ( size_t j = i; j < n; j++ )
         {
-            double v = std::abs( a[i][j] );
+            double v = std::abs( a[j][i] );
             if ( v > max_val )
             {
                 max_val = v;

--- a/src/rawtoaces_core/core_math.h
+++ b/src/rawtoaces_core/core_math.h
@@ -12,9 +12,21 @@ namespace core
 namespace math
 {
 
+// Set to `true` in order to use the Eigen implementation of linear algebra.
+// For use in the unit tests only.
 extern bool use_eigen;
 
+// Set to `true` in order to use the Ceres implementation of non-linear solver.
+// For use in the unit tests only.
+extern bool use_ceres;
+
+// Runtime check for the library being built with Eigen support.
+// For use in the unit tests only.
 bool has_eigen();
+
+// Runtime check for the library being built with Ceres support.
+// For use in the unit tests only.
+bool has_ceres();
 
 bool inverse(
     const std::vector<std::vector<double>> &src_mat,

--- a/src/rawtoaces_core/core_math_priv.h
+++ b/src/rawtoaces_core/core_math_priv.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the rawtoaces Project.
+
+#pragma once
+
+#include <vector>
+
+namespace rta
+{
+namespace core
+{
+namespace math
+{
+
+// Contains the declarations of the private functions,
+// exposed here for unit-testing.
+
+// XYZ to LAB conversion.
+template <typename T> void XYZ_to_LAB( const T ( &in )[3], T ( &out )[3] );
+
+// The derivative of the `XYZ_to_LAB` function, see above.
+template <typename T>
+void XYZ_to_LAB_prime(
+    const T ( &arg )[3], const T ( &arg_prime )[3], T ( &out )[3] );
+
+template <typename T_dst, typename T_src>
+std::vector<T_dst> change_type( const std::vector<T_src> &vec );
+
+/// Solve a system of linear equations using Gauss elimination.
+bool solve_linear(
+    std::vector<std::vector<double>> &a, std::vector<double> &b );
+
+bool solve_spectral_transform(
+    const std::vector<std::vector<double>> &source_RGB,
+    const std::vector<std::vector<double>> &target_XYZ,
+    double                                  error_threshold,
+    size_t                                  max_steps,
+    int                                     verbosity,
+    std::vector<std::vector<double>>       &out_IDT_matrix );
+
+} // namespace math
+} // namespace core
+} // namespace rta

--- a/src/rawtoaces_core/rawtoaces_core.cpp
+++ b/src/rawtoaces_core/rawtoaces_core.cpp
@@ -5,6 +5,7 @@
 
 #include <nlohmann/json.hpp>
 #include <fstream>
+#include <cmath>
 
 #include "rawtoaces_core_priv.h"
 #include "core_math.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,6 +146,11 @@ add_test ( NAME Test_DNGIdt COMMAND Test_DNGIdt )
 add_executable (
 	Test_Math
 	testMath.cpp
+ 
+    # for testing stderr
+    test_data_helpers.cpp
+    test_data_helpers.h
+    test_utils.cpp
 )
 
 target_link_libraries(
@@ -153,6 +158,8 @@ target_link_libraries(
     PUBLIC
         ${RAWTOACES_CORE_LIB}
         OpenImageIO::OpenImageIO
+    PRIVATE
+        nlohmann_json::nlohmann_json
 )
 
 setup_test_coverage(Test_Math)

--- a/tests/config_tests/CMakeLists.txt
+++ b/tests/config_tests/CMakeLists.txt
@@ -8,7 +8,7 @@
 # Usage: 
 #    cmake -S . -B build -D rawtoaces_DIR=PATH_TO_INSTALL_DIR 
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project( rawtoaces_config_test )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/tests/config_tests/core/CMakeLists.txt
+++ b/tests/config_tests/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 #include_directories( "${CMAKE_CURRENT_SOURCE_DIR}" )
 

--- a/tests/config_tests/util/CMakeLists.txt
+++ b/tests/config_tests/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 #include_directories( "${CMAKE_CURRENT_SOURCE_DIR}" )
 

--- a/tests/testIDT.cpp
+++ b/tests/testIDT.cpp
@@ -5536,6 +5536,74 @@ void testIDT_calculate_transform_Training_Data_Empty()
         solver, expected_error_training_data_not_initialized );
 }
 
+void test_compare_solvers()
+{
+    // Test that all 4 types of solver [with/without eigen] x [with/without ceres]
+    // calculate the same transform matrix.
+    // Calculates and compares the four matrices over 48 different colour
+    // temperatures.
+
+    if ( !rta::core::math::has_eigen() && !rta::core::math::has_ceres() )
+        return;
+
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    size_t eigen_steps = rta::core::math::has_eigen() ? 2 : 1;
+    size_t ceres_steps = rta::core::math::has_ceres() ? 2 : 1;
+
+    rta::core::SpectralData camera;
+    load_file( "camera/Nikon_D200_380_780_5.json", camera );
+
+    rta::core::SpectralData observer;
+    load_file( "cmf/cmf_1931.json", observer );
+
+    rta::core::SpectralData training_data;
+    load_file( "training/training_spectral.json", training_data );
+
+    std::vector<std::vector<double>> matrices[4];
+
+    for ( int cct = 1500; cct <= 25000; cct += 500 )
+    {
+        std::string cct_string = std::to_string( cct );
+
+        if ( cct < 4000 )
+            cct_string = cct_string + "K";
+        else
+            cct_string = "D" + cct_string;
+
+        for ( size_t use_eigen = 0; use_eigen < eigen_steps; use_eigen++ )
+        {
+            for ( size_t use_ceres = 0; use_ceres < ceres_steps; use_ceres++ )
+            {
+                rta::core::math::use_eigen = use_eigen;
+                rta::core::math::use_ceres = use_ceres;
+
+                rta::core::SpectralSolver solver;
+                solver.camera        = camera;
+                solver.observer      = observer;
+                solver.training_data = training_data;
+                OIIO_CHECK_ASSERT( solver.find_illuminant( cct_string ) );
+                OIIO_CHECK_ASSERT( solver.calculate_WB() );
+                OIIO_CHECK_ASSERT( solver.calculate_transform() );
+
+                size_t index    = ( use_ceres << 1 ) + use_eigen;
+                matrices[index] = solver.transform_matrix;
+
+                if ( index != 0 )
+                {
+                    const auto &mat1 = matrices[0];
+                    const auto &mat2 = matrices[index];
+
+                    for ( size_t row = 0; row < 3; row++ )
+                        for ( size_t col = 0; col < 3; col++ )
+                            OIIO_CHECK_EQUAL_THRESH(
+                                mat1[row][col], mat2[row][col], 1e-6 );
+                }
+            }
+        }
+    }
+}
+
 int main( int, char ** )
 {
     testIDT_LoadCameraSpst();
@@ -5561,6 +5629,8 @@ int main( int, char ** )
     testIDT_calculate_transform_Observer_Wrong_Size();
     testIDT_calculate_transform_Training_Data_Not_Initialized();
     testIDT_calculate_transform_Training_Data_Empty();
+
+    test_compare_solvers();
 
     return unit_test_failures;
 }

--- a/tests/testMath.cpp
+++ b/tests/testMath.cpp
@@ -10,10 +10,14 @@
 #include <OpenImageIO/unittest.h>
 
 #include "../src/rawtoaces_core/core_math.h"
+#include "../src/rawtoaces_core/core_math_priv.h"
 #include "../src/rawtoaces_core/define.h"
+#include "test_utils.h"
 
 void test_inverse_failure()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::vector<std::vector<double>> result;
     // Empty
     OIIO_CHECK_ASSERT( !rta::core::math::inverse( {}, result ) );
@@ -22,10 +26,16 @@ void test_inverse_failure()
     // Non-invertible
     OIIO_CHECK_ASSERT( !rta::core::math::inverse(
         { { 1.0, 2.0, 3.0 }, { 1.0, 2.0, 3.0 }, { 1.0, 2.0, 3.0 } }, result ) );
+    // Non 3x3
+    OIIO_CHECK_ASSERT(
+        rta::core::math::inverse( { { 1.0, 2.0 }, { 2.0, 3.0 } }, result ) ==
+        rta::core::math::use_eigen );
 }
 
 void test_inverse_success()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     const double( &M1 )[3][3] = rta::core::XYZ_acesrgb_3;
     const double( &M2 )[3][3] = rta::core::acesrgb_XYZ_3;
 
@@ -48,6 +58,8 @@ void test_inverse_success()
 
 void test_transpose()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     double M[6][3] = {
         { 1.0, 0.0, 0.0 }, { 0.0, 2.0, 0.0 }, { 0.0, 0.0, 3.0 },
         { 1.0, 1.0, 2.0 }, { 2.0, 2.0, 3.0 }, { 3.0, 3.0, 4.0 }
@@ -85,6 +97,8 @@ void test_transpose()
 
 void test_mat_mat_mult()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::vector<std::vector<double>> MV1( 3, std::vector<double>( 3 ) );
     std::vector<std::vector<double>> MV2( 3, std::vector<double>( 3 ) );
     for ( size_t i = 0; i < 3; i++ )
@@ -102,6 +116,8 @@ void test_mat_mat_mult()
 
 void test_mat_vec_mult()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     double M1[3][3] = { { 1.0000000000, 0.0000000000, 0.0000000000 },
                         { 0.0000000000, 0.5000000000, 0.0000000000 },
                         { 0.0000000000, 0.0000000000, 0.3333333333 }
@@ -124,6 +140,8 @@ void test_mat_vec_mult()
 
 void testIDT_XytoXYZ()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     double              xy[3] = { 0.7347, 0.2653 };
     std::vector<double> XYZV =
         rta::core::math::xy_to_XYZ( std::vector<double>( xy, xy + 2 ) );
@@ -136,6 +154,8 @@ void testIDT_XytoXYZ()
 
 void testIDT_Uvtoxy()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     double              uv[2] = { 0.7347, 0.2653 };
     double              xy[2] = { 0.658530026, 0.158530026 };
     std::vector<double> xyV =
@@ -149,6 +169,8 @@ void testIDT_Uvtoxy()
 
 void testIDT_UvtoXYZ()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     double              uv[2]  = { 0.7347, 0.2653 };
     double              XYZ[3] = { 0.658530026, 0.158530026, 0.18293995 };
     std::vector<double> XYZV =
@@ -162,6 +184,8 @@ void testIDT_UvtoXYZ()
 
 void testIDT_XYZTouv()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     double              XYZ[3] = { 0.658530026, 0.158530026, 0.18293995 };
     double              uv[2]  = { 0.7347, 0.2653 };
     std::vector<double> uvV =
@@ -175,6 +199,8 @@ void testIDT_XYZTouv()
 
 void testIDT_GetCAT()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::vector<double> dIV(
         rta::core::d50_white_point_XYZ, rta::core::d50_white_point_XYZ + 3 );
     std::vector<double> dOV(
@@ -197,6 +223,8 @@ void testIDT_GetCAT()
 
 void test_XYZtoLAB()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::vector<std::vector<double>> XYZ( 190, ( std::vector<double>( 3 ) ) );
     for ( size_t i = 0; i < 190; i++ )
         for ( size_t j = 0; j < 3; j++ )
@@ -409,6 +437,8 @@ void test_XYZtoLAB()
 
 void test_GetCalcXYZt()
 {
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
     std::vector<std::vector<double>> RGB( 190, ( std::vector<double>( 3 ) ) );
     const double BStart[6] = { 1.0, 0.0, 0.0, 1.0, 0.0, 0.0 };
 
@@ -616,10 +646,221 @@ void test_GetCalcXYZt()
             OIIO_CHECK_EQUAL_THRESH( XYZ_test[i][j], XYZ[i][j], 1e-5 );
 }
 
+void test_solve_linear_failure()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    std::vector<std::vector<double>> a = { { 1.0, 2.0 }, { 1.0, 2.0 } };
+    std::vector<double>              b = { 0.0, 0.0 };
+    bool result                        = rta::core::math::solve_linear( a, b );
+    OIIO_CHECK_ASSERT( !result );
+}
+
+void test_solve_linear_success()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    std::vector<std::vector<double>> a = { { 2.0, 3.0 }, { 4.0, 9.0 } };
+    std::vector<double>              b = { 6.0, 15.0 };
+    bool result                        = rta::core::math::solve_linear( a, b );
+    OIIO_CHECK_ASSERT( result );
+    OIIO_CHECK_EQUAL( b[0], 1.5 );
+    OIIO_CHECK_EQUAL( b[1], 1 );
+}
+
+void test_change_type()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    std::vector<double> in_vec = { 1.0, 2.0, 3.0 };
+
+    auto out_vec = rta::core::math::change_type<double>( in_vec );
+    for ( size_t i = 0; i < 3; i++ )
+        OIIO_CHECK_EQUAL( out_vec[i], in_vec[i] );
+}
+
+void test_XYZ_to_LAB()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    double in_val[3][3] = { { 0.7, 0.5, 0.1 },
+                            { 0.2, 0.7, 0.0 },
+                            { 0.2, 0.3, 0.7 } };
+
+    double out_val[3][3] = { { 76.0693, 47.1017, 65.9083 },
+                             { 86.9969, -151.55, 149.995 },
+                             { 61.6542, -42.3147, -43.6942 } };
+
+    for ( size_t i = 0; i < 3; i++ )
+    {
+        double result[3];
+        rta::core::math::XYZ_to_LAB( in_val[i], result );
+
+        for ( size_t j = 0; j < 3; j++ )
+            OIIO_CHECK_EQUAL_THRESH( result[j], out_val[i][j], 1e-3 );
+    }
+}
+
+void test_XYZ_to_LAB_prime()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    double in_val[3][3] = { { 0.7, 0.5, 0.1 },
+                            { 0.2, 0.7, 0.0 },
+                            { 0.2, 0.3, 0.7 } };
+
+    double out_val[3][3] = { { 12.2759, -31.7728, -71.6664 },
+                             { 9.80923, 6.45249, -450.31 },
+                             { 17.2565, -25.6478, 4.38389 } };
+
+    for ( size_t i = 0; i < 3; i++ )
+    {
+        double result[3];
+        rta::core::math::XYZ_to_LAB_prime(
+            in_val[i], { 0.1, 0.2, 0.3 }, result );
+
+        for ( size_t j = 0; j < 3; j++ )
+            OIIO_CHECK_EQUAL_THRESH( result[j], out_val[i][j], 1e-3 );
+    }
+}
+
+void test_nonlinear_solver(
+    const std::vector<std::vector<double>> &source_RGB,
+    const std::vector<std::vector<double>> &target_XYZ,
+    double                                  threshold,
+    int                                     max_steps,
+    bool                                    expected_success,
+    const std::vector<std::vector<double>> &expected_result,
+    const std::vector<std::string>         &expected_stdout,
+    const std::vector<std::string>         &expected_stderr )
+{
+    std::vector<std::vector<double>> result;
+    bool                             success;
+
+    std::string stdout_output;
+    std::string stderr_output = capture_stderr( [&]() {
+        stdout_output = capture_stdout( [&]() {
+            success = rta::core::math::solve_spectral_transform(
+                source_RGB, target_XYZ, threshold, max_steps, 4, result );
+        } );
+    } );
+
+    OIIO_CHECK_EQUAL( success, expected_success );
+    ASSERT_CONTAINS_ALL( stdout_output, expected_stdout );
+    ASSERT_CONTAINS_ALL( stderr_output, expected_stderr );
+
+    if ( success && expected_result.size() > 0 )
+    {
+        for ( size_t i = 0; i < 3; i++ )
+            for ( size_t j = 0; j < 3; j++ )
+                OIIO_CHECK_EQUAL_THRESH(
+                    result[i][j], expected_result[i][j], 1e-6 );
+    }
+}
+
+void test_nonlinear_solver_nan()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    std::vector<std::vector<double>> source_RGB = { { NAN, 0.0, 0.0 } };
+
+    std::vector<std::vector<double>> target_XYZ = { { 1.0, 0.0, 0.0 } };
+
+    test_nonlinear_solver(
+        source_RGB,
+        target_XYZ,
+        1e-17,
+        300,
+        false,
+        {},
+        {},
+        { "FAILURE ", "Jacobian evaluation failed." } );
+}
+
+void test_nonlinear_solver_steps()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    std::vector<std::vector<double>> source_RGB = { { 1.0, 0.0, 0.0 },
+                                                    { 0.0, 1.0, 0.0 },
+                                                    { 0.0, 0.0, 1.0 } };
+
+    std::vector<std::vector<double>> target_XYZ = { { 1.0, 0.0, 0.0 },
+                                                    { 0.0, 1.0, 0.0 },
+                                                    { 0.0, 0.0, 1.0 } };
+
+    test_nonlinear_solver(
+        source_RGB,
+        target_XYZ,
+        1e-17,
+        2, // low number of iterations
+        true,
+        {},
+        {},
+        { "NO_CONVERGENCE ", "Maximum number of iterations reached." } );
+}
+
+void test_nonlinear_solver_gradient()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    std::vector<std::vector<double>> source_RGB = { { 0.0, 0.0, 0.0 } };
+
+    std::vector<std::vector<double>> target_XYZ = { { 0.0, 0.0, 0.0 } };
+
+    test_nonlinear_solver(
+        source_RGB,
+        target_XYZ,
+        1e-17,
+        300,
+        true,
+        {},
+        {},
+        { "CONVERGENCE ", "Gradient tolerance reached." } );
+}
+
+void test_nonlinear_solver_tolerance()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    std::vector<std::vector<double>> source_RGB = { { 1.0, 0.0, 0.0 },
+                                                    { 0.0, 1.0, 0.0 },
+                                                    { 0.0, 0.0, 1.0 },
+                                                    { 1.0, 1.0, 1.0 } };
+
+    std::vector<std::vector<double>> target_XYZ = { { 1.0, 0.0, 0.0 },
+                                                    { 0.0, 1.0, 0.0 },
+                                                    { 0.0, 0.0, 1.0 },
+                                                    { 1.0, 1.0, 1.0 } };
+
+    std::vector<std::vector<double>> expected_matrix = {
+        { 0.999713, 0.000067, 0.000218 },
+        { -0.475184, 1.375594, 0.099589 },
+        { -0.001995, 0.000078, 1.001918 }
+    };
+
+    test_nonlinear_solver(
+        source_RGB,
+        target_XYZ,
+        1e-17,
+        300,
+        true,
+        expected_matrix,
+        { "iter      cost      cost_change", "   0  9.998321e+04    0.00e+00" },
+        { "Solver Summary",
+          "Cost:",
+          "Initial                          9.998321e+04",
+          "Final                            3.518131e+01",
+          "Change                           9.994803e+04",
+          "Termination: ",
+          "CONVERGENCE ",
+          "Function tolerance reached." } );
+}
+
 int main( int, char ** )
 {
-    size_t steps = rta::core::math::has_eigen() ? 2 : 1;
-    for ( size_t use_eigen = 0; use_eigen < steps; use_eigen++ )
+    size_t eigen_steps = rta::core::math::has_eigen() ? 2 : 1;
+    for ( size_t use_eigen = 0; use_eigen < eigen_steps; use_eigen++ )
     {
         rta::core::math::use_eigen = use_eigen;
 
@@ -635,7 +876,26 @@ int main( int, char ** )
         testIDT_GetCAT();
         test_XYZtoLAB();
         test_GetCalcXYZt();
+
+        size_t ceres_steps = rta::core::math::has_ceres() ? 2 : 1;
+        for ( size_t use_ceres = 0; use_ceres < ceres_steps; use_ceres++ )
+        {
+            rta::core::math::use_ceres = use_ceres;
+            test_XYZ_to_LAB();
+            test_XYZ_to_LAB_prime();
+            test_nonlinear_solver_nan();
+            test_nonlinear_solver_steps();
+            test_nonlinear_solver_gradient();
+            test_nonlinear_solver_tolerance();
+        }
     }
+
+    // These don't depend on eigen or ceres, so we only test once.
+    rta::core::math::use_eigen = false;
+    rta::core::math::use_ceres = false;
+    test_change_type();
+    test_solve_linear_failure();
+    test_solve_linear_success();
 
     return unit_test_failures;
 }

--- a/tests/testMath.cpp
+++ b/tests/testMath.cpp
@@ -668,6 +668,23 @@ void test_solve_linear_success()
     OIIO_CHECK_EQUAL( b[1], 1 );
 }
 
+void test_solve_linear_pivot()
+{
+    std::cout << std::endl << __FUNCTION__ << std::endl;
+
+    // Row 0 has a valid col-0 pivot (2.0) but a larger value in col 1 (100.0).
+    // Partial pivoting must search column 0, not row 0, or elimination breaks.
+    // Ax = b, solution x = [1, 1]:
+    //   2x + 100y = 102
+    //   0x +   1y = 1
+    std::vector<std::vector<double>> a = { { 2.0, 100.0 }, { 0.0, 1.0 } };
+    std::vector<double>              b = { 102.0, 1.0 };
+    bool result                        = rta::core::math::solve_linear( a, b );
+    OIIO_CHECK_ASSERT( result );
+    OIIO_CHECK_EQUAL( b[0], 1.0 );
+    OIIO_CHECK_EQUAL( b[1], 1.0 );
+}
+
 void test_change_type()
 {
     std::cout << std::endl << __FUNCTION__ << std::endl;
@@ -896,6 +913,7 @@ int main( int, char ** )
     test_change_type();
     test_solve_linear_failure();
     test_solve_linear_success();
+    test_solve_linear_pivot();
 
     return unit_test_failures;
 }


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

Implements a non-linear solver making the dependency on Ceres optional. Both solvers are available when built with Ceres, and the Ceres is used by default. The solvers are switchable in runtime, but that option is not currently exposed to the users, only being used in unit tests.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->

Yes, full coverage.
There are extensive tests comparing the new solver with the old one.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
