### PR TITLE
[feat] adds --bad-pixels-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A help message with a description of all command line options can be obtained by
         --flip VAL                      If not -1, override the orientation specified in the metadata. 1..8 correspond to EXIF orientation codes (0 = none, 3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.) (default: -1)
         --denoise-threshold VAL         Wavelet denoising threshold (default: 0)
         --demosaic STR                  Demosaicing algorithm. Supported options: 'linear', 'VNG', 'PPG', 'AHD', 'DCB', 'AHD-Mod', 'AFD', 'VCD', 'Mixed', 'LMMSE', 'AMaZE', 'DHT', 'AAHD', 'AHD'. (default: AHD)
+        --bad-pixels-path STR           Path to a file describing bad pixels in the libraw format.
     Benchmarking and debugging:
         --list-formats                  Shows the list of formats supported for RAW processing.
         --list-cameras                  Shows the list of cameras supported in spectral mode.

--- a/include/rawtoaces/image_converter.h
+++ b/include/rawtoaces/image_converter.h
@@ -212,6 +212,12 @@ public:
         /// 'DHT', 'AAHD', 'AHD'.
         std::string demosaic_algorithm = "AHD";
 
+        /// A path to the file containing a list of bad bixels in libraw format:
+        /// a plain text where each line describes a single bad pixel using
+        /// three numbers separated by whitespace for the column, row and UNIX
+        /// timestamp.
+        std::string bad_pixels_path;
+
         //----------------------------------------------------------------------
         // Global config:
 

--- a/src/bindings/py_util.cpp
+++ b/src/bindings/py_util.cpp
@@ -93,6 +93,8 @@ void util_bindings( nanobind::module_ &m )
     settings.def_rw(
         "demosaic_algorithm", &ImageConverter::Settings::demosaic_algorithm );
     settings.def_rw(
+        "bad_pixels_path", &ImageConverter::Settings::bad_pixels_path );
+    settings.def_rw(
         "database_directories",
         &ImageConverter::Settings::database_directories );
     settings.def_rw( "overwrite", &ImageConverter::Settings::overwrite );

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -1028,6 +1028,11 @@ void ImageConverter::init_parser( OIIO::ArgParse &arg_parser )
         .defaultval( "AHD" )
         .action( OIIO::ArgParse::store() );
 
+    arg_parser.arg( "--bad-pixels-path" )
+        .help( "Path to a file describing bad pixels in the libraw format." )
+        .metavar( "STR" )
+        .action( OIIO::ArgParse::store() );
+
     arg_parser.separator( "Benchmarking and debugging:" );
 
     arg_parser.arg( "--list-formats" )
@@ -1351,6 +1356,7 @@ bool ImageConverter::parse_parameters( const OIIO::ArgParse &arg_parser )
     settings.use_timing       = arg_parser["use-timing"].get<int>();
     settings.disable_cache    = arg_parser["disable-cache"].get<int>();
     settings.disable_exiftool = arg_parser["disable-exiftool"].get<int>();
+    settings.bad_pixels_path  = arg_parser["bad-pixels-path"].get();
 
 #if ( RTA_ENABLE_LENSFUN )
     std::string lens_correction = arg_parser["lens-correction"].get();
@@ -1897,6 +1903,7 @@ bool ImageConverter::configure(
     options["raw:HighlightMode"]      = settings.highlight_mode;
     options["raw:Demosaic"]           = settings.demosaic_algorithm;
     options["raw:threshold"]          = settings.denoise_threshold;
+    options["raw:bad_pixels"]         = settings.bad_pixels_path;
 
     if ( settings.crop_box[2] != 0 && settings.crop_box[3] != 0 )
     {

--- a/tests/python/test_image_converter.py
+++ b/tests/python/test_image_converter.py
@@ -365,7 +365,10 @@ class TestSettings:
                                         
         converter.settings.demosaic_algorithm = "AHD"
         assert converter.settings.demosaic_algorithm == "AHD"
-                                        
+
+        converter.settings.bad_pixels_path = "test_path"
+        assert converter.settings.bad_pixels_path == "test_path"
+
         converter.settings.database_directories = ["dir1", "dir2"]
         assert converter.settings.database_directories == ["dir1", "dir2"]
                                         


### PR DESCRIPTION

## Description

adds `--bad-pixels-path` parameter which provides a list of bad pixels to libraw.

## Tests

yes


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
