### PR TITLE
[fix] remove unsupported demosaic algos

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ A help message with a description of all command line options can be obtained by
         --crop-mode STR                 Cropping mode. Supported options: 'none' (write out the full sensor area), 'soft' (write out full image, mark the crop as the display window), 'hard' (write out only the crop area). (default: soft)
         --flip VAL                      If not -1, override the orientation specified in the metadata. 1..8 correspond to EXIF orientation codes (0 = none, 3 = 180 deg, 6 = 90 deg CCW, 8 = 90 deg CW.) (default: -1)
         --denoise-threshold VAL         Wavelet denoising threshold (default: 0)
-        --demosaic STR                  Demosaicing algorithm. Supported options: 'linear', 'VNG', 'PPG', 'AHD', 'DCB', 'AHD-Mod', 'AFD', 'VCD', 'Mixed', 'LMMSE', 'AMaZE', 'DHT', 'AAHD', 'AHD'. (default: AHD)
+        --demosaic STR                  Demosaicing algorithm. Supported options: 'linear', 'VNG', 'PPG', 'AHD', 'DCB', 'DHT', 'AAHD'. (default: AHD)
         --bad-pixels-path STR           Path to a file describing bad pixels in the libraw format.
     Benchmarking and debugging:
         --list-formats                  Shows the list of formats supported for RAW processing.

--- a/include/rawtoaces/image_converter.h
+++ b/include/rawtoaces/image_converter.h
@@ -208,8 +208,7 @@ public:
         float scale = 1.0f;
 
         /// Demosaicing algorithm. Supported options: 'linear', 'VNG', 'PPG',
-        /// 'AHD', 'DCB', 'AHD-Mod', 'AFD', 'VCD', 'Mixed', 'LMMSE', 'AMaZE',
-        /// 'DHT', 'AAHD', 'AHD'.
+        /// 'AHD', 'DCB', 'DHT', 'AAHD.
         std::string demosaic_algorithm = "AHD";
 
         /// A path to the file containing a list of bad bixels in libraw format:

--- a/src/docs/api/python/image_converter.rst
+++ b/src/docs/api/python/image_converter.rst
@@ -137,7 +137,7 @@ ImageConverter
 
       Demosaicing algorithm. Supported options::
         
-       linear VNG PPG AHD DCB AHD-Mod AFD VCD Mixed LMMSE AMaZE DHT AAHD AHD'
+       linear VNG PPG AHD DCB DHT AAHD
 
     .. py:attribute:: list[str] database_directories
 

--- a/src/rawtoaces_util/image_converter.cpp
+++ b/src/rawtoaces_util/image_converter.cpp
@@ -1030,8 +1030,7 @@ void ImageConverter::init_parser( OIIO::ArgParse &arg_parser )
     arg_parser.arg( "--demosaic" )
         .help(
             "Demosaicing algorithm. Supported options: 'linear', 'VNG', 'PPG', "
-            "'AHD', 'DCB', 'AHD-Mod', 'AFD', 'VCD', 'Mixed', 'LMMSE', 'AMaZE', "
-            "'DHT', 'AAHD', 'AHD'." )
+            "'AHD', 'DCB', 'DHT', 'AAHD'." )
         .metavar( "STR" )
         .defaultval( "AHD" )
         .action( OIIO::ArgParse::store() );
@@ -1322,10 +1321,9 @@ bool ImageConverter::parse_parameters( const OIIO::ArgParse &arg_parser )
     }
 
     auto demosaic_algorithm = arg_parser["demosaic"].get();
-    static std::set<std::string> demosaic_algorithms = {
-        "linear", "VNG",   "PPG",   "AHD",   "DCB", "AHD-Mod", "AFD",
-        "VCD",    "Mixed", "LMMSE", "AMaZE", "DHT", "AAHD",    "AHD"
-    };
+    static std::set<std::string> demosaic_algorithms = { "linear", "VNG", "PPG",
+                                                         "AHD",    "DCB", "DHT",
+                                                         "AAHD" };
 
     if ( demosaic_algorithms.count( demosaic_algorithm ) != 1 )
     {


### PR DESCRIPTION
<!-- This is just a guideline and set of reminders about what constitutes -->
<!-- a good PR. Feel free to delete all this matter and replace it with   -->
<!-- your own detailed message about the PR, assuming you hit all the     -->
<!-- important points made below.                                         -->


## Description

A bunch of demosaicing algos have been removed from Libraw some time ago: AHD-Mod, AFD, VCD, Mixed, LMMSE, AMaZE.

Rawtoaces checks if the value provided by the user is one of the supported types and passes it to OIIO.
OIIO parses the string and maps it to numeric `user_qual` param passed to Libraw.
Libraw still accepts the removed user_qual values and falls back to AHD is the requested mode is no longer supported.

With the proposed change rawtoaces will now hard fail if one of the mentioned algos is requested. I'm not certain if this is the best way, as both OIIO and Libraw would still accept the value. Perhaps it would be better to show a warning until this is also addressed on the OIIO side.

## Tests

<!-- Did you / should you add a testsuite case (new test, or add to an  -->
<!-- existing test) to verify that this works?                          -->


## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable. (Check if there is no
  need to update the documentation, for example if this is a bug fix that
  doesn't change the API.)
- [x] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't
  already run clang-format before submitting, I definitely will look at the CI
  test that runs clang-format and fix anything that it highlights as being
  nonconforming.
