### PR TITLE
[fix] quote the paths on the exiftool command line (#329)

### DIFF
--- a/src/rawtoaces_util/exiftool.cpp
+++ b/src/rawtoaces_util/exiftool.cpp
@@ -102,6 +102,27 @@ bool execute( const std::string &command, std::stringstream &stream )
     return success && !empty;
 }
 
+/// Quote a path for the shell that popen() runs the command with, so
+/// spaces and characters like ( ) or $ in it are passed through as is.
+static std::string quote_path( const std::string &path )
+{
+#if defined( WIN32 ) || defined( WIN64 )
+    return "\"" + path + "\"";
+#else
+    // Single quotes take everything literally. An embedded single quote is
+    // written as '\'' (close, escaped quote, reopen).
+    std::string result = "'";
+    for ( char c: path )
+    {
+        if ( c == '\'' )
+            result += "'\\''";
+        else
+            result += c;
+    }
+    return result + "'";
+#endif
+}
+
 bool perform_exiftool_call(
     const std::string                  &exiftool_path,
     const std::string                  &image_path,
@@ -110,7 +131,7 @@ bool perform_exiftool_call(
     std::map<std::string, std::string> &parsed_data,
     std::string                        &error_message )
 {
-    std::string command = exiftool_path + " -S";
+    std::string command = quote_path( exiftool_path ) + " -S";
 
     if ( no_formatting )
     {
@@ -150,7 +171,16 @@ bool perform_exiftool_call(
         }
     }
 
-    command += " " + image_path;
+    // "--" ends the options, so a relative path starting with "-" is still
+    // a file name to exiftool.
+    command += " -- " + quote_path( image_path );
+
+#if defined( WIN32 ) || defined( WIN64 )
+    // cmd.exe strips the first and the last quote of the line it is given
+    // when there are more than two; an extra pair around the whole line
+    // keeps the ones around the paths.
+    command = "\"" + command + "\"";
+#endif
 
     std::stringstream stream;
     if ( !execute( command, stream ) )

--- a/tests/testExiftool.cpp
+++ b/tests/testExiftool.cpp
@@ -8,6 +8,8 @@
 
 #include "../src/rawtoaces_util/exiftool.h"
 
+#include <filesystem>
+
 #include "test_utils.h"
 #include <OpenImageIO/unittest.h>
 
@@ -174,6 +176,59 @@ void test_focus_distance()
     }
 }
 
+void testExiftool_path_with_spaces()
+{
+    std::cout << "\n" << __FUNCTION__ << "\n";
+
+    set_exiftool_path( false, true );
+
+    // Spaces, an apostrophe and parentheses in the names, the way photo
+    // managers and browsers produce them.
+    TestDirectory         test_dir;
+    std::filesystem::path dir =
+        std::filesystem::path( test_dir.path() ) / "dir with spaces";
+    std::filesystem::create_directories( dir );
+    std::filesystem::path file = dir / "Battery's Park (1).NEF";
+    std::filesystem::copy_file(
+        test_file, file, std::filesystem::copy_options::overwrite_existing );
+
+    OIIO::ImageSpec spec;
+    std::string     output;
+    bool            success = rta::util::exiftool::fetch_metadata(
+        spec, file.string(), { "cameraMake", "cameraModel" }, output );
+
+    OIIO_CHECK_ASSERT( success );
+    OIIO_CHECK_EQUAL( output, "" );
+    OIIO_CHECK_EQUAL(
+        spec.get_string_attribute( "cameraMake" ), "NIKON CORPORATION" );
+    OIIO_CHECK_EQUAL(
+        spec.get_string_attribute( "cameraModel" ), "NIKON D200" );
+}
+
+void testExiftool_path_leading_dash()
+{
+    std::cout << "\n" << __FUNCTION__ << "\n";
+
+    set_exiftool_path( false, true );
+
+    // A relative path starting with "-" looks like an option to exiftool.
+    // It has to be relative to trigger that, so the copy goes into the
+    // working directory.
+    std::filesystem::path file = "-Battery Park.NEF";
+    std::filesystem::copy_file(
+        test_file, file, std::filesystem::copy_options::overwrite_existing );
+
+    OIIO::ImageSpec spec;
+    std::string     output;
+    bool            success = rta::util::exiftool::fetch_metadata(
+        spec, file.string(), { "cameraMake" }, output );
+    std::filesystem::remove( file );
+
+    OIIO_CHECK_ASSERT( success );
+    OIIO_CHECK_EQUAL(
+        spec.get_string_attribute( "cameraMake" ), "NIKON CORPORATION" );
+}
+
 int main( int, char ** )
 {
     testExiftool_tool_not_found();
@@ -183,6 +238,8 @@ int main( int, char ** )
     testExiftool_bad_key();
 
     test_focus_distance();
+    testExiftool_path_with_spaces();
+    testExiftool_path_leading_dash();
 
     return unit_test_failures;
 }


### PR DESCRIPTION
## Description

`perform_exiftool_call` concatenates the exiftool path and the image path into the command line unquoted, so a space or a shell character in either path breaks the call. With a space in the image path the call even looks successful, exiftool prints `File not found` for each fragment but stdout is not empty, and `fetch_metadata` returns true with no metadata. The cases I tried are in #329.

Since the line goes through a shell, an unquoted name can also run commands: a file called `a;id;.NEF` runs `id`. Quoting closes that as well.

This quotes both paths. On sh that is single quotes, nothing inside them is interpreted, an embedded single quote becomes `'\''`. On Windows it is double quotes, and because cmd.exe strips the first and the last quote of the line when there are more than two, the whole line gets an extra pair around it (the usual `cmd /c ""prog" "arg""` idiom). The image path is also preceded by `--`, otherwise a relative name starting with `-` is parsed by exiftool as an option (`Invalid TAG name`). I can only test the sh side here, the Windows runners exercise the cmd.exe side through the existing `testExiftool_tool_in_env` / `tool_in_path` tests (relative exiftool path, no spaces) and the new tests.

One thing quoting does not cover on Windows: cmd.exe expands `%VAR%` even inside double quotes, so a name like `100%TEMP%.NEF` would still be mangled there. That needs CreateProcess instead of `_popen` and I left it out. The outer pair of quotes is added in `perform_exiftool_call` rather than in `execute()` to stay out of the lines #328 changes; it can move there once one of the two has landed.

## Tests

- `testExiftool_path_with_spaces`: copies BatteryPark.NEF to `<tmp>/dir with spaces/Battery's Park (1).NEF` and fetches `cameraMake` / `cameraModel` from there; the apostrophe goes through the `'\''` escape on sh. Fails on main (the apostrophe gives a shell syntax error; with spaces alone the call succeeds with an empty make), passes with this change.
- `testExiftool_path_leading_dash`: copies the fixture to `-Battery Park.NEF` in the working directory and fetches `cameraMake` through that relative name. Fails on main, passes with `--`.

Full ctest 17/17, install and config_tests on Ubuntu 24.04 with gcc 13.3; ASan+UBSan and clang-format 16 clean. Outside the test suite I ran 144 generated names through `fetch_metadata` (every printable ASCII character, `'''`, `$'..'`, UTF-8, ~3000 character paths, glob patterns, an exiftool binary reached through a directory with odd characters): on main 104 worked, 7 returned success with empty metadata and 33 failed; with this change all 143 legitimate ones work and the one deliberate command injection attempt is rejected.

This touches exiftool.cpp and testExiftool.cpp like #328 does, in different places; I checked that the two branches merge cleanly in either order.

## Checklist:

- [x] I have read the [contribution guidelines](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/CONTRIBUTING.md).
- [x] I have read the [Policy on AI Coding Assistants](https://github.com/AcademySoftwareFoundation/rawtoaces/blob/main/docs/AI_Policy.md) and if I used AI coding assistants, I have an `Assisted-by: TOOL / MODEL` line in the pull request description above.
- [x] I have updated the documentation, if applicable. (Internal function, no documentation change needed.)
- [x] I have ensured that the change is tested somewhere in the testsuite (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project. If I haven't already run clang-format before submitting, I definitely will look at the CI test that runs clang-format and fix anything that it highlights as being nonconforming.

Assisted-by: Claude Code / Claude Opus 5
(Used to write the probe that tried the four path variants and to run the CI steps locally; I reviewed the change myself.)
